### PR TITLE
(maint) fix retrieve_mode

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -71,7 +71,7 @@ module Puppet::Util::NetworkDevice::Cisco_ios
         re_enable = Regexp.new(%r{#{commands['default']['enable_prompt']}})
         re_conf_t = Regexp.new(%r{#{commands['default']['config_prompt']}})
         re_conf_if = Regexp.new(%r{#{commands['default']['interface_prompt']}})
-        prompt = send_command(connection, "\n")
+        prompt = send_command(connection, ' ')
 
         return ModeState::LOGGED_IN if prompt.match re_login
         return ModeState::CONF_T if prompt.match re_conf_t

--- a/spec/unit/puppet/provider/network_interface/network_interface_spec.rb
+++ b/spec/unit/puppet/provider/network_interface/network_interface_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Provider::NetworkInterface::NetworkInterface do
     allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
     allow(Puppet::Util::NetworkDevice::Cisco_ios::Device).to receive(:transport).and_return(transport)
     allow(transport).to receive(:connection).and_return(connection)
-    allow(connection).to receive(:cmd).with("\n").and_return('cisco-c6503e#')
+    allow(connection).to receive(:cmd).with(' ').and_return('cisco-c6503e#')
     allow(connection).to receive(:cmd).with('String' => 'enable', 'Match' => %r{^Password:.*$|#})
                                       .and_return('Password:')
     allow(transport).to receive(:enable_password).and_return('test_pass')

--- a/spec/unit/puppet/provider/ntp_auth_key/ntp_auth_key_spec.rb
+++ b/spec/unit/puppet/provider/ntp_auth_key/ntp_auth_key_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Provider::NtpAuthKey::NtpAuthKey do
     allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
     allow(Puppet::Util::NetworkDevice::Cisco_ios::Device).to receive(:transport).and_return(transport)
     allow(transport).to receive(:connection).and_return(connection)
-    allow(connection).to receive(:cmd).with("\n").and_return('cisco-c6503e#')
+    allow(connection).to receive(:cmd).with(' ').and_return('cisco-c6503e#')
     allow(connection).to receive(:cmd).with('String' => 'enable', 'Match' => %r{^Password:.*$|#})
                                       .and_return('Password:')
     allow(transport).to receive(:enable_password).and_return('test_pass')

--- a/spec/unit/puppet/provider/ntp_config/ntp_config_spec.rb
+++ b/spec/unit/puppet/provider/ntp_config/ntp_config_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Provider::NtpConfig::NtpConfig do
     allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
     allow(Puppet::Util::NetworkDevice::Cisco_ios::Device).to receive(:transport).and_return(transport)
     allow(transport).to receive(:connection).and_return(connection)
-    allow(connection).to receive(:cmd).with("\n").and_return('cisco-c6503e#')
+    allow(connection).to receive(:cmd).with(' ').and_return('cisco-c6503e#')
     allow(connection).to receive(:cmd).with('String' => 'enable', 'Match' => %r{^Password:.*$|#})
                                       .and_return('Password:')
     allow(transport).to receive(:enable_password).and_return('test_pass')

--- a/spec/unit/puppet/provider/ntp_server/ntp_server_spec.rb
+++ b/spec/unit/puppet/provider/ntp_server/ntp_server_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Provider::NtpServer::NtpServer do
     allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
     allow(Puppet::Util::NetworkDevice::Cisco_ios::Device).to receive(:transport).and_return(transport)
     allow(transport).to receive(:connection).and_return(connection)
-    allow(connection).to receive(:cmd).with("\n").and_return('cisco-c6503e#')
+    allow(connection).to receive(:cmd).with(' ').and_return('cisco-c6503e#')
     allow(connection).to receive(:cmd).with('String' => 'enable', 'Match' => %r{^Password:.*$|#})
                                       .and_return('Password:')
     allow(transport).to receive(:enable_password).and_return('test_pass')

--- a/spec/unit/puppet/provider/snmp_community/snmp_community_spec.rb
+++ b/spec/unit/puppet/provider/snmp_community/snmp_community_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Provider::SnmpCommunity::SnmpCommunity do
     allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
     allow(Puppet::Util::NetworkDevice::Cisco_ios::Device).to receive(:transport).and_return(transport)
     allow(transport).to receive(:connection).and_return(connection)
-    allow(connection).to receive(:cmd).with("\n").and_return('cisco-c6503e#')
+    allow(connection).to receive(:cmd).with(' ').and_return('cisco-c6503e#')
     allow(connection).to receive(:cmd).with('String' => 'enable', 'Match' => %r{^Password:.*$|#})
                                       .and_return('Password:')
     allow(transport).to receive(:enable_password).and_return('test_pass')

--- a/spec/unit/puppet/provider/snmp_notification_receiver/snmp_notification_receiver_spec.rb
+++ b/spec/unit/puppet/provider/snmp_notification_receiver/snmp_notification_receiver_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Provider::SnmpNotificationReceiver::SnmpNotificationReceiver do
     allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
     allow(Puppet::Util::NetworkDevice::Cisco_ios::Device).to receive(:transport).and_return(transport)
     allow(transport).to receive(:connection).and_return(connection)
-    allow(connection).to receive(:cmd).with("\n").and_return('cisco-c6503e#')
+    allow(connection).to receive(:cmd).with(' ').and_return('cisco-c6503e#')
     allow(connection).to receive(:cmd).with('String' => 'enable', 'Match' => %r{^Password:.*$|#})
                                       .and_return('Password:')
     allow(transport).to receive(:enable_password).and_return('test_pass')

--- a/spec/unit/puppet/provider/syslog_server/syslog_server_spec.rb
+++ b/spec/unit/puppet/provider/syslog_server/syslog_server_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Provider::SyslogServer::SyslogServer do
     allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
     allow(Puppet::Util::NetworkDevice::Cisco_ios::Device).to receive(:transport).and_return(transport)
     allow(transport).to receive(:connection).and_return(connection)
-    allow(connection).to receive(:cmd).with("\n").and_return('cisco-c6503e#')
+    allow(connection).to receive(:cmd).with(' ').and_return('cisco-c6503e#')
     allow(connection).to receive(:cmd).with('String' => 'enable', 'Match' => %r{^Password:.*$|#})
                                       .and_return('Password:')
     allow(transport).to receive(:enable_password).and_return('test_pass')

--- a/spec/unit/puppet/provider/syslog_settings/syslog_settings_spec.rb
+++ b/spec/unit/puppet/provider/syslog_settings/syslog_settings_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Provider::SyslogSettings::SyslogSettings do
     allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
     allow(Puppet::Util::NetworkDevice::Cisco_ios::Device).to receive(:transport).and_return(transport)
     allow(transport).to receive(:connection).and_return(connection)
-    allow(connection).to receive(:cmd).with("\n").and_return('cisco-c6503e#')
+    allow(connection).to receive(:cmd).with(' ').and_return('cisco-c6503e#')
     allow(connection).to receive(:cmd).with('String' => 'enable', 'Match' => %r{^Password:.*$|#})
                                       .and_return('Password:')
     allow(transport).to receive(:enable_password).and_return('test_pass')


### PR DESCRIPTION
On cat-2960g sending "\n" to detect enable mode was problematic.

It appears net-ssh-telnet sends a newline with the cmd function and the device was not happy about it.

Passing just a space appears to work on both 6500 and 2960.