### PR TITLE
(FM-6845) define require method in task

### DIFF
--- a/tasks/config_save.rb
+++ b/tasks/config_save.rb
@@ -3,6 +3,11 @@
 require 'json'
 require 'puppet'
 require 'puppet/util/network_device/config'
+require 'timeout'
+
+def require_module_file(file)
+  require "#{Puppet[:plugindest]}/#{file}"
+end
 
 # PARAMETERS: JSON object from STDIN with the following fields:
 #
@@ -90,10 +95,7 @@ end
 # Save.
 
 begin
-  # This https://puppet.com/docs/puppet/latest/configuration.html#libdir states:
-  #   In fact, the autoload mechanism is responsible for making sure this directory is in Ruby’s search path
-  # But, in fact, it is not.
-  require "#{Puppet[:libdir]}/puppet/util/network_device/cisco_ios/device"
+  require_module_file('puppet/util/network_device/cisco_ios/device')
   cisco_ios_device = Puppet::Util::NetworkDevice::Cisco_ios::Device.new(target_device_url)
   result = cisco_ios_device.running_config_save
   return_success("running-config saved to startup-config: #{result}")


### PR DESCRIPTION
Puppet's libdir is not included in LOAD_PATH within the context of tasks,
and tasks execute in /opt/puppetlabs/pxp-agent/tasks-cache, 
so we cannot use `require_relative` either.

With this commit:

Defined a self-documenting method to require a file in Puppet[:plugindest],
which by default is Puppet[:libdir].

Maintenance: explicitly `require 'timeout'` which is used in this task.