### PR TITLE
(NETDEV-38) Update banner motd to support multiline

### DIFF
--- a/lib/puppet/provider/banner/command.yaml
+++ b/lib/puppet/provider/banner/command.yaml
@@ -1,11 +1,12 @@
 ---
 get_values:
-  default: 'show running-config | include banner'
+  default: 'show running-config | begin banner'
 attributes:
   name:
     default:
       get_value: 'default'
   motd:
     default:
-      get_value: 'banner motd .C (?<motd>.*) .C'
-      set_value: 'banner motd c <motd> c'
+      get_value: 'banner motd .C(?<motd>.*).C'
+      set_value: 'banner motd #<motd>#'
+      multiline: 'true'

--- a/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
+++ b/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
@@ -152,9 +152,12 @@ module PuppetX::CiscoIOS
       return unless attribute_safe_to_run(commands_hash, attribute)
       default_value = PuppetX::CiscoIOS::Utility.attribute_value_foraged_from_command_hash(commands_hash, attribute, 'default', true)
       can_have_no_match = PuppetX::CiscoIOS::Utility.attribute_value_foraged_from_command_hash(commands_hash, attribute, 'can_have_no_match', true)
+      multiline = PuppetX::CiscoIOS::Utility.attribute_value_foraged_from_command_hash(commands_hash, attribute, 'multiline', true)
       regex = PuppetX::CiscoIOS::Utility.attribute_value_foraged_from_command_hash(commands_hash, attribute, 'get_value')
       returned_value = if regex.nil?
                          []
+                       elsif multiline
+                         output.scan(%r{#{regex}}m)
                        else
                          output.scan(%r{#{regex}})
                        end

--- a/spec/unit/puppet/provider/banner/test_data.yaml
+++ b/spec/unit/puppet/provider/banner/test_data.yaml
@@ -2,20 +2,20 @@
 default:
   read_tests:
     "banner":
-      cli: "show running-config | include banner\nbanner login ^C hi there ^C\nbanner motd ^C meoooow ^C"
+      cli: "show running-config | begin banner\nbanner login ^C\nanother\n multiline banner\n^C\nbanner motd ^C\nSweet\nmultiline\n  motd\n^C"
       expectations:
       - :name: 'default'
-        :motd: 'meoooow'
+        :motd: "\nSweet\nmultiline\n  motd\n"
   update_tests:
     "motd = cats":
       commands:
-      - "banner motd c meow c"
+      - "banner motd #meow#"
       instance:
        :name: 'default'
        :motd: 'meow'
     "motd = dogs":
       commands:
-      - "banner motd c woof c"
+      - "banner motd #woof#"
       instance:
        :name: 'default'
        :motd: 'woof'


### PR DESCRIPTION
This commit adds the ability to match multiline motd
Attributes can now be flagged with `multiline` to trigger multiline regex matching