### PR TITLE
(maint) Update hardwaremodel fact

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -240,7 +240,7 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
       begin
         version_info = @connection.cmd('show version')
         raise Puppet::Error, 'Could not retrieve facts' unless version_info
-        facts['hardwaremodel'] = version_info[%r{(WS-C\S*)}, 1]
+        facts['hardwaremodel'] = version_info[%r{cisco\s+(\S+).+processor}i, 1]
         facts['serialnumber'] = version_info[%r{Processor board ID (\w*)}, 1]
         facts['operatingsystemrelease'] = version_info[%r{(?i)version.(\S*),}, 1]
       end


### PR DESCRIPTION
This commit changes to a more universal regex for hardwaremodel matching.
Tested against various IOS Cats, Cat9k, CSR1kv, and some examples of legacy routers.