### PR TITLE
(FM-6986) Fix banner regex

### DIFF
--- a/lib/puppet/provider/banner/command.yaml
+++ b/lib/puppet/provider/banner/command.yaml
@@ -7,6 +7,6 @@ attributes:
       get_value: 'default'
   motd:
     default:
-      get_value: 'banner motd .C(?<motd>.*).C'
+      get_value: 'banner motd \^C(?<motd>.*)\^C'
       set_value: 'banner motd #<motd>#'
       multiline: 'true'


### PR DESCRIPTION
The banner regex was not matching explicitly on the control character and causing oddness