### PR TITLE
(FM-6990) ios_config idempotent via master and regex options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Please see the netdev_stdlib docs https://github.com/puppetlabs/netdev_stdlib/bl
 * [`cisco_ios::install`](#cisco_iosinstall): Private class
 ### Resource types
 * [`banner`](#banner): Set the banner on the device.
-* [`ios_config`](#ios_config): Execute an arbitary configuration against the cicso_ios device with or without a check for idempotency.
+* [`ios_config`](#ios_config): Execute an arbitrary configuration against the cisco_ios device with or without a check for idempotency.
 
 #### cisco_ios
 
@@ -131,7 +131,7 @@ The MOTD banner.
 
 #### ios_config
 
-Execute an arbitary configuration against the cicso_ios device with or without a check for idempotency
+Execute an arbitrary configuration against the cisco_ios device with or without a check for idempotency
 
 ##### attributes
 
@@ -158,6 +158,12 @@ Default value: CONF_T.
 ###### `idempotent_regex`
 
 Expected string, when running a regex against the 'show running-config'.
+
+###### `idempotent_regex_options`
+
+Array of one or more options which control how the pattern can match.
+
+Allowed values: ['ignorecase', 'extended', 'multiline', 'fixedencoding', 'noencoding']
 
 ###### `negate_idempotent_regex`
 

--- a/examples/ios_config.pp
+++ b/examples/ios_config.pp
@@ -1,0 +1,24 @@
+# Simple examples
+ios_config { 'bill':
+  command          => 'ip domain-name bill',
+  idempotent_regex => 'ip domain-name bill'
+}
+
+# Example including regex options
+ios_config { 'jimmy':
+  command                  => 'ip domain-name jimmy',
+  idempotent_regex         => 'ip domain-name JIMMY',
+  idempotent_regex_options => ['ignorecase'],
+}
+
+# Advanced example
+ios_config { 'test-acl':
+    command          => "
+    no ip access-list extended test-acl
+    ip access-list extended test-acl
+      permit tcp 192.168.10.0 0.0.0.255 any eq 22 log
+      permit udp 192.168.10.0 0.0.0.255 any
+    ",
+    # This regex has a negative lookahead at the end to ensure we do not match any addtional lines
+    idempotent_regex => 'ip access-list extended test-acl\\n permit tcp 192.168.10.0 0.0.0.255 any eq 22 log\\n permit udp 192.168.10.0 0.0.0.255 any\\n(?!\s+(deny|permit))',
+}

--- a/lib/puppet/provider/ios_config/ios.rb
+++ b/lib/puppet/provider/ios_config/ios.rb
@@ -4,11 +4,33 @@ require_relative '../../../puppet_x/puppetlabs/cisco_ios/utility'
 # Execute and arbitary command against the cicso_ios device with or without a check for idempotency
 class Puppet::Provider::IosConfig::IosConfig
   def get(_context)
-    new_instance_fields = []
-    new_instance = {}
-    new_instance[:name] = 'This resource only works with apply or "puppet device -t"'
-    new_instance_fields << new_instance
-    new_instance_fields
+    new_instance = [{ name: 'default' }]
+    new_instance
+  end
+
+  # We use canonicalize here to check for idempotency as these are dynamic resources
+  def canonicalize(context, resources)
+    resources.each do |resource|
+      # We strip leading and trailing whitespace to help ensure valid commands are sent
+      resource[:command].strip!
+      next unless resource[:idempotent_regex]
+      output = context.device.run_command_enable_mode('show running-config')
+      idempotent_regex = if resource[:idempotent_regex_options]
+                           # Gather array of regex options, make sure they are unique, map them to Regexp constants and bitwise or them
+                           Regexp.new(resource[:idempotent_regex], resource[:idempotent_regex_options].uniq.map { |x| Regexp.const_get(x.upcase) }.reduce(:|))
+                         else
+                           Regexp.new(resource[:idempotent_regex])
+                         end
+      match = if resource[:negate_idempotent_regex]
+                output !~ idempotent_regex
+              else
+                output =~ idempotent_regex
+              end
+      # We have matched our idempotency criteria - do not update type
+      # This is done by setting the type back to the default value so that Puppet knows it is in desired state
+      resource.delete(:command) if match
+    end
+    resources
   end
 
   def set(context, changes)
@@ -19,24 +41,9 @@ class Puppet::Provider::IosConfig::IosConfig
   end
 
   def update(context, name, should)
-    run_command = false
-    if should[:idempotent_regex].nil?
-      run_command = true
-    else
-      # run the show_all command then run the regex
-      output = context.device.run_command_enable_mode('show running-config')
-      match = if should[:negate_idempotent_check]
-                output !~ %r{#{should[:idempotent_regex]}}
-              else
-                output =~ %r{#{should[:idempotent_regex]}}
-              end
-      run_command = match.nil?
-    end
     # command mode is only conf_t for now.
-    if run_command # rubocop:disable Style/GuardClause
-      context.updating(name) do
-        context.device.run_command_conf_t_mode(should[:command])
-      end
+    context.updating(name) do
+      context.device.run_command_conf_t_mode(should[:command])
     end
   end
 end

--- a/lib/puppet/type/ios_config.rb
+++ b/lib/puppet/type/ios_config.rb
@@ -2,8 +2,8 @@ require 'puppet/resource_api'
 
 Puppet::ResourceApi.register_type(
   name: 'ios_config',
-  docs: 'Execute an arbitary configuration against the cicso_ios device with or without a check for idempotency',
-  features: ['remote_resource'],
+  docs: 'Execute an arbitary configuration against the cisco_ios device with or without a check for idempotency',
+  features: ['canonicalize', 'remote_resource'],
   attributes: {
     name:         {
       type:      'String',
@@ -18,15 +18,23 @@ Puppet::ResourceApi.register_type(
       type:    'Optional[Enum["CONF_T"]]',
       desc:    'The command line mode to be in, when executing the command',
       default: 'CONF_T',
+      behaviour: :parameter,
     },
     idempotent_regex:      {
       type:    'Optional[String]',
       desc:    "Expected string, when running a regex against the 'show running-config'",
+      behaviour: :parameter,
+    },
+    idempotent_regex_options:      {
+      type:    'Optional[Array[Enum["ignorecase","extended","multiline","fixedencoding","noencoding"]]]',
+      desc:    'Array of one or more options which control how the pattern can match.',
+      behaviour: :parameter,
     },
     negate_idempotent_regex:      {
       type:    'Optional[Boolean]',
       desc:    'Negate the regex used with idempotent_regex',
       default: false,
+      behaviour: :parameter,
     },
   },
 )

--- a/spec/acceptance/ios_config_spec.rb
+++ b/spec/acceptance/ios_config_spec.rb
@@ -22,15 +22,16 @@ describe 'ios_config' do
     expect(result).to match(%r{domain.*jimmy})
   end
 
-  it 'command and idempotent_regex, should stay set to jimmy' do
+  it 'command and case insensitive, idempotent_regex, should stay set to jimmy' do
     pp = <<-EOS
     ios_config { "jimmy":
       command => 'ip domain-name bill',
-      idempotent_regex => 'ip domain-name jimmy'
+      idempotent_regex => 'ip domain-name JIMMY',
+      idempotent_regex_options => ['ignorecase'],
     }
     EOS
     make_site_pp(pp)
-    run_device(allow_changes: true)
+    run_device(allow_changes: false)
     # Use domain_name for check
     result = run_resource('network_dns')
     expect(result).to match(%r{domain.*jimmy})


### PR DESCRIPTION
This PR adds two major sets of functionality

The first is idempotency when being run from a master.  We use the canonicalize feature of RSAPI to execute idempotent_regex when set to determine if resource is already in desired state.

The second is regex options via idempotent_regex_options.  This allows users to specify regex options such as ignorecase and multiline.

```Puppet
ios_config { 'vty100':
    command          => "
    line vty 100
     login local
      transport input telnet ssh",
    idempotent_regex => "line VTY 100\n login local\n transport input telnet ssh\n",
    idempotent_regex_options => ['ignorecase'],
  }

ios_config { 'vty200':
    command          => "
    line vty 200
     login local
      transport input telnet ssh",
    idempotent_regex => "line VTY 200\n login local\n transport input telnet ssh\n",
    idempotent_regex_options => ['ignorecase'],
  }
```

![image](https://user-images.githubusercontent.com/3383063/40698284-e7e095ac-6393-11e8-91db-8273e87a6a36.png)

I still need to add some acceptance tests and documentation updates.