### PR TITLE
(maint) - Update Clone from ssh to https 

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -13,7 +13,7 @@ Gemfile:
       - gem: 'backport_dig'
         condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
       - gem: 'puppetmodule-netdev_stdlib'
-        git: 'git@github.com:puppetlabs/netdev_stdlib.git'
+        git: 'https://github.com/puppetlabs/netdev_stdlib.git'
         from_env: true
       - gem: 'net-ssh-telnet'
     ':development':

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development do
   gem "simplecov-console",                             require: false
 end
 group :default do
-  gem "puppetmodule-netdev_stdlib", :git => 'git@github.com:puppetlabs/netdev_stdlib.git'
+  gem "puppetmodule-netdev_stdlib", :git => 'https://github.com/puppetlabs/netdev_stdlib.git'
   gem "net-ssh-telnet", require: false
   gem "backport_dig", require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')
 end


### PR DESCRIPTION
This is necessary for cloning to work in our travis.org since this repo has been made public. It does not support ssh cloning.