### PR TITLE
(FM-7029) Fixup network_dns

### DIFF
--- a/lib/puppet/provider/network_dns/command.yaml
+++ b/lib/puppet/provider/network_dns/command.yaml
@@ -6,15 +6,15 @@ set_values:
 attributes:
   servers:
     default:
-      get_value: 'ip name-server (?<servers>\S*)'
+      get_value: 'ip name-server\s+(?<list>.*)'
       set_value: 'ip name-server <servers>'
       unset_value: 'no ip name-server <servers>'
   domain:
     default:
-      get_value: 'ip domain-name (?<domain>\S*)'
-      set_value: '<state> ip domain-name <domain>'
+      get_value: 'ip (domain-name|domain name) (?<domain>\S*)'
+      set_value: '<state> ip domain name <domain>'
   search:
     default:
-      get_value: 'ip domain-list (?<search>\S*)'
-      set_value: 'ip domain-list <search>'
-      unset_value: 'no ip domain-list <search>'
+      get_value: 'ip (domain-list|domain list) (?<search>\S*)'
+      set_value: 'ip domain list <search>'
+      unset_value: 'no ip domain list <search>'

--- a/lib/puppet/provider/network_dns/ios.rb
+++ b/lib/puppet/provider/network_dns/ios.rb
@@ -21,6 +21,8 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       new_instance[:ensure] = 'present'
       new_instance[:search] = [].push(new_instance[:search]) if new_instance[:search].is_a?(String)
       new_instance[:servers] = [].push(new_instance[:servers]) if new_instance[:servers].is_a?(String)
+      # servers can come as either a single value or space separated list - deal with it (⌐■_■)
+      new_instance[:servers] = new_instance[:servers].flatten.map(&:split).flatten if new_instance[:servers]
       new_instance.delete_if { |_k, v| v.nil? }
       new_instance_fields << new_instance
       new_instance_fields

--- a/spec/acceptance/network_dns_spec.rb
+++ b/spec/acceptance/network_dns_spec.rb
@@ -31,7 +31,7 @@ describe 'network_dns' do
     pp = <<-EOS
     network_dns { "default":
       servers => ['2.2.2.2', '2.2.2.3'],
-      search => ['jim.com', 'bill.com'],
+      search => ['john.com', 'bill.com'],
       domain => 'jill.com',
       ensure => 'present',
     }
@@ -41,7 +41,7 @@ describe 'network_dns' do
     run_device(allow_changes: false)
     result = run_resource('network_dns')
     expect(result).to match(%r{domain.*jill.com})
-    expect(result).to match(%r{search.*jim.com})
+    expect(result).to match(%r{search.*john.com})
     expect(result).to match(%r{search.*bill.com})
     expect(result).to match(%r{servers.*2.2.2.3})
     expect(result).to match(%r{servers.*2.2.2.2})

--- a/spec/unit/puppet/provider/network_dns/test_data.yaml
+++ b/spec/unit/puppet/provider/network_dns/test_data.yaml
@@ -2,13 +2,13 @@
 default:
   read_tests:
     "network_dns, everything here":
-      cli: "ip name-server 1.1.1.1\nip name-server 1.1.1.3\nip domain-list jim.com\nip domain-list bill.com\nip domain-name amy.com\n"
+      cli: "ip name-server 1.1.1.1\nip name-server 1.1.1.3\nip name-server 1.0.0.1 8.8.8.8\nip domain list jim.com\nip domain-list bill.com\nip domain name amy.com\n"
       expectations:
       - :name: 'default'
         :ensure: 'present'
         :domain: "amy.com"
         :search: ["jim.com", "bill.com"]
-        :servers: ["1.1.1.1", "1.1.1.3"]
+        :servers: ["1.1.1.1", "1.1.1.3", "1.0.0.1", "8.8.8.8"]
   update_tests:
     "network_dns add/delete":
       is:
@@ -24,6 +24,6 @@ default:
         :search: ["jim.com", "bill.com"]
         :servers: ["1.1.1.3"]
       cli:
-        - "ip domain-list bill.com"
+        - "ip domain list bill.com"
         - "no ip name-server 1.1.1.1"
-        - "ip domain-name amy.com"
+        - "ip domain name amy.com"


### PR DESCRIPTION
This commit fixes a couple of issues with network_dns
First is the change in CLI from `domain-name` / `domain-list` to `domain name` / `domain list`
Starting in IOS 12.2 the commands were moved to the later format.

Although systems still support setting via the old style, and even report in it - it is no longer preferred.
Addtionally most systems now report the value in new style.

This commit takes that into account by reading either format, and only setting in the new one.

The second is the handling of name-server's specified on a single line.
At some point IOS moved from multiple single value entries to a single multi-value entry

```
ip name-server 1.1.1.1
ip name-server 1.0.0.1
ip name-server 192.168.198.1

ip name-server 192.168.198.1 1.1.1.1 1.0.0.1
```

This commit takes those values into account.  Some of the magic there is handled in the provider itself.
If there is a better way to handle this directly in the regex that would be even more better :)