### PR TITLE
(FM-7025) Move to netdev_stdlib 0.14.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,10 @@
     {
       "name": "puppetlabs/resource_api",
       "version_requirement": ">= 0.2.0 < 1.0.0"
+    },
+    {
+      "name": "puppetlabs/netdev_stdlib",
+      "version_requirement": ">= 0.14.0 < 1.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -127,9 +127,6 @@ EOS
         # install puppet-resource_api on to the server
         on(host, 'puppetserver gem install puppet-resource_api --no-ri --no-rdoc')
         on(host, 'puppet module install puppetlabs-resource_api')
-        # install latest netdev stdlib on the server
-        on(host, 'wget https://github.com/puppetlabs/netdev_stdlib/archive/master.tar.gz')
-        on(host, 'puppet module install master.tar.gz')
         apply_manifest('include cisco_ios')
         on host, puppet('plugin', 'download', '--server', host.to_s)
         on host, puppet('device', '-v', '--waitforcert', '0', '--user', 'root', '--server', host.to_s), acceptable_exit_codes: [0, 1]


### PR DESCRIPTION
Now that netdev_stdlib 0.14.0 has been released on the forge, update to use released version