### PR TITLE
(maint) expand running_config_save regex

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -279,7 +279,7 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
       copy_command = "copy running-config #{dest}"
       run_command_conf_t_mode(shhh_command)
       copy_result = run_command_enable_mode(copy_command)
-      copy_status = copy_result.match(%r{\d+ bytes copied in \d+\.\d+ secs \(\d+ bytes\/sec\)})
+      copy_status = copy_result.match(%r{\[OK\]|\d+ bytes copied in \d+\.\d+ secs \(\d+ bytes\/sec\)})
       raise "Unexpected results for: #{copy_command}" unless copy_status
       copy_status
     end


### PR DESCRIPTION
This commit adds matching of `[OK]` in addition to bytes copied.