### PR TITLE
(FM-7034) Update run_command_conf_t_mode and default prompt matching

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -121,22 +121,29 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
       elsif retrieve_mode != ModeState::ENABLED
         enable_cmd = { 'String' => 'enable', 'Match' => %r{^Password:.*$|#} }
         send_command(connection, enable_cmd)
-        send_command(connection, @enable_password)
+        send_command(connection, 'String' => @enable_password, 'Match' => re_enable)
       end
-      send_command(connection, command, true)
+      send_command(connection, { 'String' => command, 'Match' => re_enable }, true)
     end
 
-    def run_command_conf_t_mode(command)
+    def run_command_conf_t_mode(command, multiline = false)
       re_conf_t = Regexp.new(%r{#{commands['default']['config_prompt']}})
       conf_t_cmd = { 'String' => 'conf t', 'Match' => re_conf_t }
       if retrieve_mode_special_config_mode
-        send_command(connection, 'String' => 'exit', 'Match' => conf_t_regex)
+        send_command(connection, 'String' => 'exit', 'Match' => re_conf_t)
       elsif retrieve_mode != ModeState::ENABLED
         run_command_enable_mode(conf_t_cmd)
       elsif retrieve_mode == ModeState::ENABLED
         send_command(connection, conf_t_cmd)
       end
-      send_command(connection, command, true)
+      if multiline
+        command.split("\n").each do |config_line|
+          send_command(connection, config_line, true)
+        end
+        send_command(connection, ' ')
+      else
+        send_command(connection, { 'String' => command, 'Match' => re_conf_t }, true)
+      end
     end
 
     def run_command_interface_mode(interface_name, command)
@@ -250,7 +257,7 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
         'Host' => config['address'],
         'Username' => config['username'],
         'Password' => config['password'],
-        'Prompt' =>  %r{[#>]\s?\z},
+        'Prompt' =>  %r{[#>]\s?$},
         'Port' => config['port'] || 22,
       )
       @enable_password = config['enable_password']


### PR DESCRIPTION
This commit fixes a couple of issues.  The first is the default prompt matching was incorrect.
Was matching on end of overall string - not just the line.
The second is the matching of prompts inside run_command_conf_t_mode.  Being more explicit
and supporting multiline option for future enhancement of ios_config