### PR TITLE
(FM-7067) fix banner set regex

### DIFF
--- a/lib/puppet/provider/banner/command.yaml
+++ b/lib/puppet/provider/banner/command.yaml
@@ -8,5 +8,5 @@ attributes:
   motd:
     default:
       get_value: 'banner motd \^C(?<motd>.*)\^C'
-      set_value: 'banner motd #<motd>#'
+      set_value: 'banner motd %<motd>%'
       multiline: 'true'

--- a/spec/unit/puppet/provider/banner/test_data.yaml
+++ b/spec/unit/puppet/provider/banner/test_data.yaml
@@ -9,13 +9,13 @@ default:
   update_tests:
     "motd = cats":
       commands:
-      - "banner motd #meow#"
+      - "banner motd %meow%"
       instance:
        :name: 'default'
        :motd: 'meow'
     "motd = dogs":
       commands:
-      - "banner motd #woof#"
+      - "banner motd %woof%"
       instance:
        :name: 'default'
        :motd: 'woof'


### PR DESCRIPTION
We were using a # as the control char for setting banners - this conflices with the prompt
My bad.