### PR TITLE
(FM-7067) Send a newline on Config T mode to clear prompt

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -130,13 +130,15 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
       re_conf_t = Regexp.new(%r{#{commands['default']['config_prompt']}})
       conf_t_cmd = { 'String' => 'conf t', 'Match' => re_conf_t }
       if retrieve_mode_special_config_mode
-        send_command(connection, 'String' => 'exit', 'Match' => conf_t_regex)
+        send_command(connection, 'String' => 'exit', 'Match' => re_conf_t)
       elsif retrieve_mode != ModeState::ENABLED
         run_command_enable_mode(conf_t_cmd)
       elsif retrieve_mode == ModeState::ENABLED
         send_command(connection, conf_t_cmd)
       end
       send_command(connection, command, true)
+      # Belt and braces approach to potential motd matching as a prompt - send a space with an implicit newline to clear the prompt
+      send_command(connection, ' ', true)
     end
 
     def run_command_interface_mode(interface_name, command)


### PR DESCRIPTION
This prevents any previous config eg. Banner changes from
being picked up as the current prompt.