### PR TITLE
(maint) Fix os fact and add hostname fact

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -268,8 +268,9 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
         version_info = @connection.cmd('show version')
         raise Puppet::Error, 'Could not retrieve facts' unless version_info
         facts['hardwaremodel'] = version_info[%r{cisco\s+(\S+).+processor}i, 1]
+        facts['hostname'] = version_info[%r{(\S+)\s+uptime}, 1]
         facts['serialnumber'] = version_info[%r{Processor board ID (\w*)}, 1]
-        facts['operatingsystemrelease'] = version_info[%r{(?i)version.(\S*),}, 1]
+        facts['operatingsystemrelease'] = version_info[%r{(?i)IOS Software.*Version\s+([^,\s]+)}, 1]
       end
       return_facts.merge(facts)
     end


### PR DESCRIPTION
Previous operatingsystem regex expcted a comma seperator, which is not present in XE 3
Added hostname fact which can be derived from 'show ver'

Tested against IOS 12.2, 15, XE 3.6, 16

https://docs.google.com/spreadsheets/d/1wwHrgwHwCVJMJqnb4mrzMoaXKOYcoQQ-b10DSmKyqbI/edit?usp=sharing