### PR TITLE
Update 'create issue' link in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "summary": "Management of Cisco Catalyst (IOS)",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/cisco_ios",
+  "issues_url": "https://tickets.puppetlabs.com/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&customfield_14200=19807&priority=6",
   "dependencies": [
     {
       "name": "puppetlabs/resource_api",


### PR DESCRIPTION
Updating the issues_url entry in metadata.json - previously the link just brought the user to the Modules Jira project to allow them to raise an issue - with this change it will open a new issue and pre-populate some fields to help categorise the tickets better and prevent Network Automation tickets ending up in the Modules triage report.