### PR TITLE
(FM-7224) Split command and connection timeout and make configurable

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -29,6 +29,11 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
     attr_accessor :url, :transport, :facts, :commands
 
     def send_command(connection_to_use, options, debug = false)
+      if options.is_a?(Hash)
+        options['Timeout'] = @command_timeout unless options.key?('Timeout')
+      elsif options.is_a?(String)
+        options = { 'String' => options, 'Timeout' => @command_timeout }
+      end
       return_value = connection_to_use.cmd(options)
       unknown_command = commands['default']['unknown_command']
       invalid_input = commands['default']['invalid_input']
@@ -261,8 +266,10 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
         'Password' => config['password'],
         'Prompt' =>  %r{#{commands['default']['connect_prompt']}},
         'Port' => config['port'] || 22,
+        'Timeout' => config['timeout'] || 30,
       )
       @enable_password = config['enable_password']
+      @command_timeout = config['command_timeout'] || 120
       # IOS will page large results which breaks prompt search
       @connection.cmd('terminal length 0')
       @facts = parse_device_facts


### PR DESCRIPTION
Prior to this commit we were not configuring the timeout variable which is 10 seconds by default.
This is inadequate for systems with large configs or higher latency
Default values are now 30 seconds for connection and 120 seconds for commands.
They can be configured in the device config as timeout and command_timeout