### PR TITLE
(FM-7184/FM-7197) Handle authentication errors and custom prompts

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/command.yaml
+++ b/lib/puppet/util/network_device/cisco_ios/command.yaml
@@ -1,10 +1,13 @@
 ---
 default:
   connect_prompt: '[#>]\s?\z'
+  access_denied: '.*Access denied'
   unknown_command: '^.*% Unknown command.*$'
   invalid_input:  '^.*% Invalid input.*$'
   incomplete_command:  '^.*% Incomplete command.*$'
+  command_authorization_failed: '.*Command authorization failed'
   command_rejected: '^.*%Command rejected.*$'
+  error_in_authentication: '.*Error in authentication'
   line_prompt: '^.*\(config-line\).*$'
   login_prompt: '^.*>$'
   enable_prompt: '^.*#$'


### PR DESCRIPTION
This commit adds the ability use custom enable password prompts as well as handles authentication and authorization errors for commands

Users are able to specify custom prompts when using RADIUS.  This was causing issues with the module timing out.  I went with a more elegant regex that either looks an empty line (which is actually the input portion of the password prompt, or the end of the CLI prompt - which means we either threw an error, or enabled w/out asking for a password.

Also added in known authentication / authorization errors for commands so that we throw one them vs timing out.

Lastly, moved the terminal length bit to use send_command so that we can pick up errors there as well.

IOS RADIUS Config
```
aaa new-model
aaa authentication password-prompt "AD Password: "
aaa authentication username-prompt "AD Username: "
aaa authentication login default group radius local
aaa authentication enable default group radius
aaa authorization exec default group radius local if-authenticated 
aaa session-id common
radius-server host 192.168.198.40 auth-port 1812 acct-port 1813 key test123
```

Freeradius Config
```
cisco Cleartext-Password := "password"
       Service-Type = NAS-Prompt-User,
       Cisco-AVPair = "shell:priv-lvl=15"

test Cleartext-Password := "test123"
       Service-Type = NAS-Prompt-User

$enab15$   Cleartext-Password := "enableit"
           Service-Type = NAS-Prompt-User
```

IOS TACACS Config
```
aaa new-model
aaa authentication login default group tacacs+ local
aaa authentication enable default group tacacs+
aaa authorization exec default group tacacs+ local if-authenticated 
aaa authorization commands 0 default group tacacs+ local if-authenticated
aaa authorization commands 1 default group tacacs+ local if-authenticated
tacacs-server host 192.168.198.40
tacacs-server directed-request
tacacs-server key test123
```

tac_plus config
```
user = admin {
    name = "Admin User"
    member = admin
    login = des d8EnhbLx.F4d6
}

user = test {
    name = "test User"
    member = allow
    login = des d8EnhbLx.F4d6
    enable = des d8EnhbLx.F4d6
}

user = user {
    name = "test User"
    member = regular
    login = des d8EnhbLx.F4d6
    enable = des d8EnhbLx.F4d6
}

group = admin { 
        default service = permit
        service = exec { 
                priv-lvl = 15
                }
        }

group = user {
        #default service = permit
        service = exec {
                priv-lvl = 1
             }
        cmd = enable {
                deny .*
        }
        }

group =  regular {

         cmd = enable { deny .* }
         cmd = show { deny .* }
         cmd = show { permit .* }
         cmd = copy { permit .* }
         cmd = ping { permit .* }
         cmd = configure { deny .* }
         cmd = disable { permit .* }
         cmd = telnet { permit .* }
         cmd = disconnect { permit .* }
         cmd = where { permit .* }
         cmd = set { permit .* }
         cmd = clear { permit line }
         cmd = exit  { permit .* }
         cmd = debug  { permit .* }
}

group =  allow {

         cmd = enable { permit .* }
         cmd = show { permit .* }
         cmd = copy { permit .* }
         cmd = ping { permit .* }
         cmd = configure { deny .* }
         cmd = disable { permit .* }
         cmd = telnet { permit .* }
         cmd = disconnect { permit .* }
         cmd = where { permit .* }
         cmd = set { permit .* }
         cmd = clear { permit line }
         cmd = exit  { permit .* }
         cmd = debug  { permit .* }
         cmd = terminal  { permit .* }
}
```

Error examples:
```
[root@puppet ~]# puppet device -v -t cat-2960 --resource network_interface --trace
Info: retrieving resource: network_interface from cat-2960 at file:///etc/puppetlabs/puppet/devices/cat-2960.yaml
Error: enable
Password: 
% Error in authentication.

cat-2960g>


[root@puppet ~]# puppet device -v -t cat-2960 --resource network_interface --trace
Info: retrieving resource: network_interface from cat-2960 at file:///etc/puppetlabs/puppet/devices/cat-2960.yaml
Error: enable
Command authorization failed.

cat-2960g>
```