### PR TITLE
(FM-6988) Add canonicalize function to network_interface

### DIFF
--- a/lib/puppet/provider/network_interface/ios.rb
+++ b/lib/puppet/provider/network_interface/ios.rb
@@ -14,6 +14,14 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       @commands_hash = PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/command.yaml')
     end
 
+    def canonicalize(_context, resources)
+      new_resources = []
+      resources.each do |r|
+        new_resources << PuppetX::CiscoIOS::Utility.device_safe_instance(r, commands_hash)
+      end
+      new_resources
+    end
+
     def self.instances_from_cli(output)
       new_instance_fields = []
       output.scan(%r{#{PuppetX::CiscoIOS::Utility.get_instances(commands_hash)}}).each do |raw_instance_fields|

--- a/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
+++ b/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
@@ -486,5 +486,18 @@ module PuppetX::CiscoIOS
         nil
       end
     end
+
+    def self.device_safe_instance(change, commands_hash)
+      new_should = {}
+      change.each do |key, value|
+        next unless PuppetX::CiscoIOS::Utility.attribute_safe_to_run(commands_hash, key.to_s)
+        new_should[key] = value
+      end
+      new_should[:name] = change[:name]
+      if change[:ensure]
+        new_should[:ensure] = change[:ensure]
+      end
+      new_should
+    end
   end
 end

--- a/spec/acceptance/network_interface_spec.rb
+++ b/spec/acceptance/network_interface_spec.rb
@@ -29,8 +29,8 @@ describe 'network_interface' do
     result = run_resource('network_interface', 'Vlan42')
     expect(result).to match(%r{Vlan42.*})
     expect(result).to match(%r{description.*This is a test interface})
-    # MTU present on 6503 device
-    # Cannot currently get device facts from tests
-    # expect(result).to match(%r{mtu.* => 128,})
+    if result =~ %r{mtu.*}
+      expect(result).to match(%r{mtu.*128})
+    end
   end
 end

--- a/spec/unit/puppet/provider/network_interface/network_interface_spec.rb
+++ b/spec/unit/puppet/provider/network_interface/network_interface_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 module Puppet::Provider::NetworkInterface; end
 require 'puppet/provider/network_interface/ios'
@@ -25,6 +24,16 @@ RSpec.describe Puppet::Provider::NetworkInterface::NetworkInterface do
       it test_name.to_s do
         expect(PuppetX::CiscoIOS::Utility.get_speed_value_from_table_data([test['instance']], 'Speed')).to eq test['value_auto_speed']
         expect(PuppetX::CiscoIOS::Utility.get_speed_value_from_table_data([test['instance']], 'Speed', false)).to eq test['value_no_auto']
+      end
+    end
+  end
+
+  context 'Canonicalize tests:' do
+    interface = described_class.new
+    load_test_data['default']['canonicalize_tests'].each do |test_name, test|
+      it test_name.to_s do
+        fake_device(test['device'])
+        expect(interface.canonicalize(nil, [test['instance']])).to eq [test['returned']]
       end
     end
   end

--- a/spec/unit/puppet/provider/network_interface/test_data.yaml
+++ b/spec/unit/puppet/provider/network_interface/test_data.yaml
@@ -143,6 +143,30 @@ default:
        :enable: false
        :description: 'This is still a test'
        :mtu: 128
+  canonicalize_tests:
+    "2960: canonicalize remove mtu":
+      device: '2960'
+      instance:
+        :name: 'Vlan4'
+        :enable: false
+        :description: 'This is still a test'
+        :mtu: 128
+      returned:
+        :name: 'Vlan4'
+        :enable: false
+        :description: 'This is still a test'
+    "6503: canonicalize keep mtu":
+      device: '6503'
+      instance:
+        :name: 'Vlan4'
+        :enable: false
+        :description: 'This is still a test'
+        :mtu: 128
+      returned:
+        :name: 'Vlan4'
+        :enable: false
+        :description: 'This is still a test'
+        :mtu: 128
   read_table_tests:
     "Speed Duplex auto negotiate":
       status_output: "show interfaces GigabitEthernet1/0/3 status\n\nPort      Name               Status       Vlan       Duplex  Speed Type\nGi1/0/3                      connected    trunk      a-full a-1000 10/100/1000BaseTX\nlon-r015c1-cisco#"


### PR DESCRIPTION
This will check for potential non-device compatible fields such as mtu.
If found, remove from proposed changes such that we maintain idempotency.
Note that this requires the network_interface type from netdev_stdlib to
include the 'canonicalize' feature.