### PR TITLE
(FM-7283) Fix network_vlan acceptance test

### DIFF
--- a/spec/acceptance/network_vlan_spec.rb
+++ b/spec/acceptance/network_vlan_spec.rb
@@ -16,6 +16,7 @@ describe 'network_vlan' do
   it 'create a network VLAN' do
     pp = <<-EOS
     network_vlan { "43":
+      shutdown => true,
       ensure => present,
     }
     EOS


### PR DESCRIPTION
Explicitly set shutdown as true in applied manifest before expecting this in test