### PR TITLE
(FM-7396) syslog_server match new style hosts

### DIFF
--- a/lib/puppet/provider/syslog_server/command.yaml
+++ b/lib/puppet/provider/syslog_server/command.yaml
@@ -2,7 +2,7 @@
 get_values:
   default: 'show running-config | include ^logging'
 get_instances:
-  default: '^logging \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
+  default: '^logging (?:host )?\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
 set_values:
   default: '<state> logging host <name>'
 ensure_is_state:
@@ -10,7 +10,7 @@ ensure_is_state:
 attributes:
   name:
     default:
-      get_value: '^logging (?<name>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$'
+      get_value: '^logging (?:host )?(?<name>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$'
   source_interface:
     default:
       get_value: '^logging source-interface (?<source_interface>.*)$'

--- a/spec/unit/puppet/provider/syslog_server/test_data.yaml
+++ b/spec/unit/puppet/provider/syslog_server/test_data.yaml
@@ -7,7 +7,7 @@ default:
       - :name: '1.1.1.1'
         :ensure: 'present'
     "2 syslog servers":
-      cli: "show running-config all | section ^logging\nlogging exception 4096\nlogging buginf\nlogging queue-limit 256\nlogging queue-limit esm 0\nlogging queue-limit trap 256\nlogging buffered 8192 debugging\nlogging reload message-limit 1000 notifications\nlogging rate-limit console 10 except errors\nlogging console debugging\nlogging monitor debugging\nlogging cns-events informational\nlogging on\nlogging history size 1\nlogging history Unknown\nlogging system disk sup-bootdisk:\nlogging system console disk sup-bootdisk:\nlogging system console\nlogging system\nlogging trap informational\nlogging delimiter tcp\nlogging facility local7\nlogging source-interface Loopback42\nlogging 1.1.1.1\nlogging 2.2.2.2\ncisco-c6503e#"
+      cli: "show running-config all | section ^logging\nlogging exception 4096\nlogging buginf\nlogging queue-limit 256\nlogging queue-limit esm 0\nlogging queue-limit trap 256\nlogging buffered 8192 debugging\nlogging reload message-limit 1000 notifications\nlogging rate-limit console 10 except errors\nlogging console debugging\nlogging monitor debugging\nlogging cns-events informational\nlogging on\nlogging history size 1\nlogging history Unknown\nlogging system disk sup-bootdisk:\nlogging system console disk sup-bootdisk:\nlogging system console\nlogging system\nlogging trap informational\nlogging delimiter tcp\nlogging facility local7\nlogging source-interface Loopback42\nlogging 1.1.1.1\nlogging host 2.2.2.2\ncisco-c6503e#"
       expectations:
       - :name: '1.1.1.1'
         :ensure: 'present'


### PR DESCRIPTION
The command `logging host x.x.x.x` has superseded `logging x.x.x.x`.  This PR adds support for both.