### PR TITLE
(maint) Allow support for Puppet 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
This module has been tested against Puppet 6 and (future) PE 2019.0 master