### PR TITLE
FM-7435 - Wrong Puppet version quoted for 'cisco_ios' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Create a manifest with the changes you want to apply. For example:
     }
 ```
 
+**Note** Both the `--apply` and `--resource` options are only available in Puppet agent 5.5.0 and higher
+
 Run Puppet device apply to apply the changes:
 
 `puppet device  --target cisco.example.com --apply manifest.pp `

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Create a manifest with the changes you want to apply. For example:
     }
 ```
 
-**Note** Both the `--apply` and `--resource` options are only available in Puppet agent 5.5.0 and higher
+> Note: The `--apply` and `--resource` options are only available with Puppet agent 5.5.0 and higher.
 
 Run Puppet device apply to apply the changes:
 


### PR DESCRIPTION
This update provides a note about the required version of the Puppet
agent when using the newer options.