### PR TITLE
(MODULES-8068) empty canonicalize method to netdev_stdlib providers

### DIFF
--- a/lib/puppet/provider/banner/ios.rb
+++ b/lib/puppet/provider/banner/ios.rb
@@ -66,5 +66,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/network_dns/ios.rb
+++ b/lib/puppet/provider/network_dns/ios.rb
@@ -69,5 +69,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
     def create(context, _name, _should); end
 
     def delete(context, name) end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/network_snmp/ios.rb
+++ b/lib/puppet/provider/network_snmp/ios.rb
@@ -67,5 +67,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/network_trunk/ios.rb
+++ b/lib/puppet/provider/network_trunk/ios.rb
@@ -90,5 +90,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       delete_hash = { name: name, ensure: 'absent' }
       context.device.run_command_interface_mode(name, Puppet::Provider::NetworkTrunk::NetworkTrunk.commands_from_instance(delete_hash).join("\n"))
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/network_vlan/ios.rb
+++ b/lib/puppet/provider/network_vlan/ios.rb
@@ -83,5 +83,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/ntp_auth_key/ios.rb
+++ b/lib/puppet/provider/ntp_auth_key/ios.rb
@@ -60,5 +60,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/ntp_config/ios.rb
+++ b/lib/puppet/provider/ntp_config/ios.rb
@@ -68,5 +68,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/ntp_server/ios.rb
+++ b/lib/puppet/provider/ntp_server/ios.rb
@@ -67,5 +67,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       end
     end
     alias create update
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/port_channel/ios.rb
+++ b/lib/puppet/provider/port_channel/ios.rb
@@ -152,5 +152,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       should = { name: name, ensure: 'absent' }
       update(context, name, is, should)
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/radius_global/ios.rb
+++ b/lib/puppet/provider/radius_global/ios.rb
@@ -74,5 +74,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/radius_server/ios.rb
+++ b/lib/puppet/provider/radius_server/ios.rb
@@ -95,5 +95,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       end
       update(context, name, should)
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/radius_server_group/ios.rb
+++ b/lib/puppet/provider/radius_server_group/ios.rb
@@ -101,5 +101,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       is = { name: name, ensure: 'absent' }
       update(context, name, is, should)
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/snmp_community/ios.rb
+++ b/lib/puppet/provider/snmp_community/ios.rb
@@ -59,5 +59,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/snmp_notification/ios.rb
+++ b/lib/puppet/provider/snmp_notification/ios.rb
@@ -69,5 +69,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
     alias create update
 
     def delete(context, _name, should); end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/snmp_notification_receiver/ios.rb
+++ b/lib/puppet/provider/snmp_notification_receiver/ios.rb
@@ -95,5 +95,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
     end
 
     alias create update
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/snmp_user/ios.rb
+++ b/lib/puppet/provider/snmp_user/ios.rb
@@ -119,5 +119,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
     def delete(context, _name, should)
       context.device.run_command_conf_t_mode(Puppet::Provider::SnmpUser::SnmpUser.command_from_instance(should))
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/syslog_server/ios.rb
+++ b/lib/puppet/provider/syslog_server/ios.rb
@@ -62,5 +62,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/syslog_settings/ios.rb
+++ b/lib/puppet/provider/syslog_settings/ios.rb
@@ -70,5 +70,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
     def create(context, _name, _should); end
 
     def delete(context, _name); end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/tacacs_global/ios.rb
+++ b/lib/puppet/provider/tacacs_global/ios.rb
@@ -74,5 +74,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(command)
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/tacacs_server/ios.rb
+++ b/lib/puppet/provider/tacacs_server/ios.rb
@@ -176,5 +176,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         context.device.run_command_conf_t_mode(Puppet::Provider::TacacsServer::TacacsServer.old_cli_commands_from_instance(should))
       end
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/lib/puppet/provider/tacacs_server_group/ios.rb
+++ b/lib/puppet/provider/tacacs_server_group/ios.rb
@@ -102,5 +102,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       is = { name: name, ensure: 'present' }
       update(context, name, is, should)
     end
+
+    def canonicalize(_context, resources)
+      resources
+    end
   end
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -40,6 +40,29 @@ shared_examples 'resources parsed from cli' do
   end
 end
 
+shared_examples 'a noop canonicalizer' do
+  context 'canonicalize is called' do
+    let(:resources) do
+      {
+        name:   'foo',
+        ensure: 'present',
+        foo:    'bar',
+      }
+    end
+    let(:provider) { described_class.new }
+
+    it 'returns the same resource' do
+      expect(provider.canonicalize(anything, resources)[:name].object_id).to eq(resources[:name].object_id)
+      expect(provider.canonicalize(anything, resources)[:ensure].object_id).to eq(resources[:ensure].object_id)
+      expect(provider.canonicalize(anything, resources)[:foo].object_id).to eq(resources[:foo].object_id)
+    end
+
+    it 'returns unmodified resource' do
+      expect(provider.canonicalize(anything, resources)).to eq(name: 'foo', ensure: 'present', foo: 'bar')
+    end
+  end
+end
+
 shared_examples 'commands created from instance' do
   context 'Update tests:' do
     load_test_data['default']['update_tests'].each do |test_name, test|

--- a/spec/unit/puppet/provider/banner/banner_spec.rb
+++ b/spec/unit/puppet/provider/banner/banner_spec.rb
@@ -10,4 +10,5 @@ RSpec.describe Puppet::Provider::Banner::Banner do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/network_dns/network_dns_spec.rb
+++ b/spec/unit/puppet/provider/network_dns/network_dns_spec.rb
@@ -17,4 +17,6 @@ RSpec.describe Puppet::Provider::NetworkDns::NetworkDns do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/network_snmp/network_snmp_spec.rb
+++ b/spec/unit/puppet/provider/network_snmp/network_snmp_spec.rb
@@ -11,4 +11,6 @@ RSpec.describe Puppet::Provider::NetworkSnmp::NetworkSnmp do
   it_behaves_like 'resources parsed from cli'
 
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/network_trunk/network_trunk_spec.rb
+++ b/spec/unit/puppet/provider/network_trunk/network_trunk_spec.rb
@@ -17,4 +17,6 @@ RSpec.describe Puppet::Provider::NetworkTrunk::NetworkTrunk do
     end
   end
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/network_vlan/network_vlan_spec.rb
+++ b/spec/unit/puppet/provider/network_vlan/network_vlan_spec.rb
@@ -17,4 +17,6 @@ RSpec.describe Puppet::Provider::NetworkVlan::NetworkVlan do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/ntp_auth_key/ntp_auth_key_spec.rb
+++ b/spec/unit/puppet/provider/ntp_auth_key/ntp_auth_key_spec.rb
@@ -10,4 +10,5 @@ RSpec.describe Puppet::Provider::NtpAuthKey::NtpAuthKey do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/ntp_config/ntp_config_spec.rb
+++ b/spec/unit/puppet/provider/ntp_config/ntp_config_spec.rb
@@ -17,4 +17,6 @@ RSpec.describe Puppet::Provider::NtpConfig::NtpConfig do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/ntp_server/ntp_server_spec.rb
+++ b/spec/unit/puppet/provider/ntp_server/ntp_server_spec.rb
@@ -10,4 +10,6 @@ RSpec.describe Puppet::Provider::NtpServer::NtpServer do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/port_channel/port_channel_spec.rb
+++ b/spec/unit/puppet/provider/port_channel/port_channel_spec.rb
@@ -39,4 +39,6 @@ RSpec.describe Puppet::Provider::PortChannel::PortChannel do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/radius_global/radius_global_spec.rb
+++ b/spec/unit/puppet/provider/radius_global/radius_global_spec.rb
@@ -10,4 +10,6 @@ RSpec.describe Puppet::Provider::RadiusGlobal::RadiusGlobal do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/radius_server/radius_server_spec.rb
+++ b/spec/unit/puppet/provider/radius_server/radius_server_spec.rb
@@ -10,4 +10,6 @@ RSpec.describe Puppet::Provider::RadiusServer::RadiusServer do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/radius_server_group/radius_server_group_spec.rb
+++ b/spec/unit/puppet/provider/radius_server_group/radius_server_group_spec.rb
@@ -25,4 +25,6 @@ RSpec.describe Puppet::Provider::RadiusServerGroup::RadiusServerGroup do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/snmp_community/snmp_community_spec.rb
+++ b/spec/unit/puppet/provider/snmp_community/snmp_community_spec.rb
@@ -10,4 +10,6 @@ RSpec.describe Puppet::Provider::SnmpCommunity::SnmpCommunity do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/snmp_notification/snmp_notification_spec.rb
+++ b/spec/unit/puppet/provider/snmp_notification/snmp_notification_spec.rb
@@ -10,4 +10,6 @@ RSpec.describe Puppet::Provider::SnmpNotification::SnmpNotification do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/snmp_notification_receiver/snmp_notification_receiver_spec.rb
+++ b/spec/unit/puppet/provider/snmp_notification_receiver/snmp_notification_receiver_spec.rb
@@ -12,4 +12,6 @@ describe Puppet::Provider::SnmpNotificationReceiver::SnmpNotificationReceiver do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/snmp_user/snmp_user_spec.rb
+++ b/spec/unit/puppet/provider/snmp_user/snmp_user_spec.rb
@@ -34,4 +34,6 @@ RSpec.describe Puppet::Provider::SnmpUser::SnmpUser do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/syslog_server/syslog_server_spec.rb
+++ b/spec/unit/puppet/provider/syslog_server/syslog_server_spec.rb
@@ -10,4 +10,6 @@ RSpec.describe Puppet::Provider::SyslogServer::SyslogServer do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/syslog_settings/syslog_settings_spec.rb
+++ b/spec/unit/puppet/provider/syslog_settings/syslog_settings_spec.rb
@@ -17,4 +17,6 @@ RSpec.describe Puppet::Provider::SyslogSettings::SyslogSettings do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/tacacs_global/tacacs_global_spec.rb
+++ b/spec/unit/puppet/provider/tacacs_global/tacacs_global_spec.rb
@@ -10,4 +10,6 @@ RSpec.describe Puppet::Provider::TacacsGlobal::TacacsGlobal do
 
   it_behaves_like 'resources parsed from cli'
   it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/tacacs_server/tacacs_server_spec.rb
+++ b/spec/unit/puppet/provider/tacacs_server/tacacs_server_spec.rb
@@ -32,4 +32,6 @@ RSpec.describe Puppet::Provider::TacacsServer::TacacsServer do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end

--- a/spec/unit/puppet/provider/tacacs_server_group/tacacs_server_group_spec.rb
+++ b/spec/unit/puppet/provider/tacacs_server_group/tacacs_server_group_spec.rb
@@ -25,4 +25,6 @@ RSpec.describe Puppet::Provider::TacacsServerGroup::TacacsServerGroup do
       end
     end
   end
+
+  it_behaves_like 'a noop canonicalizer'
 end


### PR DESCRIPTION
In order to unblock MODULES-8070 an empty `canonicalize` method is required for all the netdev stdlib providers.

As MODULES-8070 will be adding `canonicalize` as a feature to make the netdev types more flexible in there uses.