### PR TITLE
(MODULES-8069) prepare for updates to netdev_stdlib

### DIFF
--- a/lib/puppet/provider/banner/ios.rb
+++ b/lib/puppet/provider/banner/ios.rb
@@ -45,7 +45,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::Banner::Banner.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::Banner::Banner.instances_from_cli(output)

--- a/lib/puppet/provider/network_dns/ios.rb
+++ b/lib/puppet/provider/network_dns/ios.rb
@@ -42,7 +42,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::NetworkDns::NetworkDns.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::NetworkDns::NetworkDns.instances_from_cli(output)

--- a/lib/puppet/provider/network_interface/ios.rb
+++ b/lib/puppet/provider/network_interface/ios.rb
@@ -85,7 +85,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       true
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       instances = Puppet::Provider::NetworkInterface::NetworkInterface.instances_from_cli(output)

--- a/lib/puppet/provider/network_snmp/ios.rb
+++ b/lib/puppet/provider/network_snmp/ios.rb
@@ -46,7 +46,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::NetworkSnmp::NetworkSnmp.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::NetworkSnmp::NetworkSnmp.instances_from_cli(output)

--- a/lib/puppet/provider/network_trunk/ios.rb
+++ b/lib/puppet/provider/network_trunk/ios.rb
@@ -64,7 +64,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::NetworkTrunk::NetworkTrunk.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       name_output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_interface_names(commands_hash))
       interface_names = Puppet::Provider::NetworkTrunk::NetworkTrunk.interface_names_from_cli(name_output)
 

--- a/lib/puppet/provider/network_vlan/ios.rb
+++ b/lib/puppet/provider/network_vlan/ios.rb
@@ -54,7 +54,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::NetworkVlan::NetworkVlan.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::NetworkVlan::NetworkVlan.instances_from_cli(output)

--- a/lib/puppet/provider/ntp_auth_key/ios.rb
+++ b/lib/puppet/provider/ntp_auth_key/ios.rb
@@ -38,7 +38,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::NtpAuthKey::NtpAuthKey.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::NtpAuthKey::NtpAuthKey.instances_from_cli(output)

--- a/lib/puppet/provider/ntp_config/ios.rb
+++ b/lib/puppet/provider/ntp_config/ios.rb
@@ -45,7 +45,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::NtpConfig::NtpConfig.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::NtpConfig::NtpConfig.instances_from_cli(output)

--- a/lib/puppet/provider/ntp_server/ios.rb
+++ b/lib/puppet/provider/ntp_server/ios.rb
@@ -46,7 +46,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::NtpServer::NtpServer.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::NtpServer::NtpServer.instances_from_cli(output)

--- a/lib/puppet/provider/port_channel/ios.rb
+++ b/lib/puppet/provider/port_channel/ios.rb
@@ -97,7 +97,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::PortChannel::PortChannel.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::PortChannel::PortChannel.instances_from_cli(output)

--- a/lib/puppet/provider/radius_global/ios.rb
+++ b/lib/puppet/provider/radius_global/ios.rb
@@ -53,7 +53,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::RadiusGlobal::RadiusGlobal.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::RadiusGlobal::RadiusGlobal.instances_from_cli(output)

--- a/lib/puppet/provider/radius_server/ios.rb
+++ b/lib/puppet/provider/radius_server/ios.rb
@@ -66,7 +66,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::RadiusServer::RadiusServer.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::RadiusServer::RadiusServer.instances_from_cli(output)

--- a/lib/puppet/provider/radius_server_group/ios.rb
+++ b/lib/puppet/provider/radius_server_group/ios.rb
@@ -45,7 +45,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::RadiusServerGroup::RadiusServerGroup.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::RadiusServerGroup::RadiusServerGroup.instances_from_cli(output)

--- a/lib/puppet/provider/snmp_community/ios.rb
+++ b/lib/puppet/provider/snmp_community/ios.rb
@@ -37,7 +37,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::SnmpCommunity::SnmpCommunity.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::SnmpCommunity::SnmpCommunity.instances_from_cli(output)

--- a/lib/puppet/provider/snmp_notification/ios.rb
+++ b/lib/puppet/provider/snmp_notification/ios.rb
@@ -44,7 +44,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       commands_array
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::SnmpNotification::SnmpNotification.instances_from_cli(output)

--- a/lib/puppet/provider/snmp_notification_receiver/ios.rb
+++ b/lib/puppet/provider/snmp_notification_receiver/ios.rb
@@ -53,7 +53,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       array_of_commands
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::SnmpNotificationReceiver::SnmpNotificationReceiver.instances_from_cli(output)

--- a/lib/puppet/provider/snmp_user/ios.rb
+++ b/lib/puppet/provider/snmp_user/ios.rb
@@ -75,7 +75,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::SnmpUser::SnmpUser.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       output_v3 = context.device.run_command_enable_mode(commands_hash['get_v3_values']['default'])
       (Puppet::Provider::SnmpUser::SnmpUser.instances_from_cli(output) << Puppet::Provider::SnmpUser::SnmpUser.instances_from_cli_v3(output_v3)).flatten!

--- a/lib/puppet/provider/syslog_server/ios.rb
+++ b/lib/puppet/provider/syslog_server/ios.rb
@@ -40,7 +40,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::SyslogServer::SyslogServer.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::SyslogServer::SyslogServer.instances_from_cli(output)

--- a/lib/puppet/provider/syslog_settings/ios.rb
+++ b/lib/puppet/provider/syslog_settings/ios.rb
@@ -43,7 +43,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::SyslogSettings::SyslogSettings.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::SyslogSettings::SyslogSettings.instances_from_cli(output)

--- a/lib/puppet/provider/tacacs_global/ios.rb
+++ b/lib/puppet/provider/tacacs_global/ios.rb
@@ -53,7 +53,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::TacacsGlobal::TacacsGlobal.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::TacacsGlobal::TacacsGlobal.instances_from_cli(output)

--- a/lib/puppet/provider/tacacs_server/ios.rb
+++ b/lib/puppet/provider/tacacs_server/ios.rb
@@ -139,7 +139,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       return_values
     end
 
-    def get(context)
+    def get(context, _names = nil)
       return_values = []
       return_values << test_and_get_new_instances(context)
       return_values << test_and_get_old_instances(context)

--- a/lib/puppet/provider/tacacs_server_group/ios.rb
+++ b/lib/puppet/provider/tacacs_server_group/ios.rb
@@ -45,7 +45,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       Puppet::Provider::TacacsServerGroup::TacacsServerGroup.commands_hash
     end
 
-    def get(context)
+    def get(context, _names = nil)
       output = context.device.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
       return [] if output.nil?
       Puppet::Provider::TacacsServerGroup::TacacsServerGroup.instances_from_cli(output)


### PR DESCRIPTION
netdev_stdlib will soon require all providers to implement
simple_get_filter. Since we do not gain anything from that, this commit
only accepts the parameter, but does not do any filtering.