### PR TITLE
(maint) resolving resource issue when applying manifest

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/resource_api",
-      "version_requirement": ">= 0.2.0 < 1.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
       "name": "puppetlabs/netdev_stdlib",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -122,7 +122,11 @@ EOS
 
         # install dependencies on to the server
         apply_manifest(<<PP
-          service { 'puppetserver': }
+          $puppetserver_service = $facts['pe_server_version'] ? {
+                                      /./     => 'pe-puppetserver',
+                                      default => 'puppetserver'
+                                  }
+          service { $puppetserver_service: }
           include "cisco_ios::server", "cisco_ios::proxy"
 PP
                       )


### PR DESCRIPTION
Acceptance tests failure as it was ensuring a `puppetserver` while the tests are using a full pe installation rather than just puppetserver.

Changes to spec helper ensures the correct service based on the facts.

Bumping the resource_api dependency boundary.

Should see it works here: https://jenkins-master-prod-1.delivery.puppetlabs.net/view/modules/view/networking/view/ad-hoc/view/cisco_ios/job/forge-module_puppetlabs-cisco_ios_intn-sys_full-pe-current-adhoc/PLATFORM=centos7-64cisco_host%252Cdefault.mdca%257BDEVICE_IP%253D10.0.22.162%252CDEVICE_USER%253Dadmin%252CDEVICE_PASSWORD%253Dbayda.dune.inca.nymph%252CDEVICE_ENABLE_PASSWORD%253Dbayda.dune.inca.nymph%257D,WORKER_LABEL=beaker/53/console 🤞 

Whereas master: 

```
16:05:15 Failure/Error:
16:05:15           apply_manifest(<<PP
16:05:15             service { 'puppetserver': }
16:05:15             include "cisco_ios::server", "cisco_ios::proxy"
16:05:15   PP
16:05:15                         )
16:05:15 Beaker::Host::CommandFailure:
16:05:15   Host 'gx0vb6mtgwuy84p.delivery.puppetlabs.net' exited with 1 running:
16:05:15    puppet apply --verbose /tmp/apply_manifest.pp.9buuwj
16:05:15   Last 10 lines of output were:
16:05:15   	Info: Loading facts
16:05:15   	Info: Loading facts
16:05:15   	Info: Loading facts
16:05:15   	Info: Loading facts
16:05:15   	Info: Loading facts
16:05:15   	Info: Loading facts
16:05:15   	Error: Could not find resource 'Service[pe-puppetserver]' for relationship from 'Package[Resource API on the puppetserver]' on node gx0vb6mtgwuy84p.delivery.puppetlabs.net
```