### PR TITLE
(FM-7604) only use verify_host_key on versions of net-ssh which have it

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -291,13 +291,14 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
         FileUtils.mkdir_p(dirname)
       end
 
+      verify_host_key = (Gem.loaded_specs['net-ssh'].version < Gem::Version.create('4.2.0')) ? :paranoid : :verify_host_key
       session = if !config['verify_hosts'].nil? && !config['verify_hosts']
                   Net::SSH.start(config['address'],
                                  config['username'],
                                  password: config['password'],
                                  port: config['port'] || 22,
                                  timeout: config['timeout'] || 30,
-                                 verify_host_key: false,
+                                 verify_host_key => false,
                                  user_known_hosts_file: known_hosts_file)
                 else
                   Net::SSH.start(config['address'],
@@ -305,7 +306,7 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
                                  password: config['password'],
                                  port: config['port'] || 22,
                                  timeout: config['timeout'] || 30,
-                                 verify_host_key: :very,
+                                 verify_host_key => :very,
                                  user_known_hosts_file: known_hosts_file)
                 end
 


### PR DESCRIPTION
4.2.0 of net-ssh renamed the `paranoid` option to `verify_host_key` and some Puppet versions are shipped with older versions of net-ssh which meant that `verify_host_key` was not a valid option causing failures.

This commit will use `paranoid` when the version of `net-ssh` is under 4.2.0.