### PR TITLE
(FM-7653) implement a standardized install class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,3 @@
+class cisco_ios {
+  class { 'cisco_ios::install': }
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,23 @@
+# Install device module dependencies on a puppet agent or master.
+#
+# A proxy agent needs to be classified with this class
+# before it can manage devices with this module.
+#
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class
+# before it can compile catalogs for devices with this module.
+#
+# @summary Install dependencies into the puppet agent and puppetserver service
+#
+# @example
+#   include cisco_ios::install
+
+class cisco_ios::install {
+
+  include cisco_ios::install::agent
+
+  if $facts['puppetserver_installed'] {
+    include cisco_ios::install::master
+  }
+
+}

--- a/manifests/install/agent.pp
+++ b/manifests/install/agent.pp
@@ -1,0 +1,23 @@
+# Install device module dependencies on a puppet agent.
+
+# @summary Install dependencies into the puppet agent
+#
+# @example
+#   include cisco_ios::install::agent
+
+class cisco_ios::install::agent {
+  include resource_api::install
+
+  package { 'net-ssh-telnet':
+    ensure   => present,
+    provider => 'puppet_gem',
+  }
+
+  if versioncmp($facts['rubyversion'], '2.3.0') < 0 {
+    package { 'backport_dig':
+      ensure   => present,
+      provider => 'puppet_gem',
+    }
+  }
+}
+

--- a/manifests/install/master.pp
+++ b/manifests/install/master.pp
@@ -1,0 +1,15 @@
+# Install device module dependencies on a puppet master.
+
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class
+# before it can compile catalogs for devices with this module.
+
+# @summary Install dependencies into the puppetserver service and restart
+#
+# @example
+#   include cisco_ios::install::master
+
+class cisco_ios::install::master {
+  include resource_api::install::master
+}
+

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -6,6 +6,9 @@
 #
 # @example
 #   include cisco_ios::proxy
+#
+# Deprecated by cisco_ios::install::agent
+
 class cisco_ios::proxy {
   include resource_api::agent
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -6,6 +6,9 @@
 #
 # @example
 #   include cisco_ios::server
+#
+# Deprecated by cisco_ios::install::master
+
 class cisco_ios::server {
   include resource_api::server
 }


### PR DESCRIPTION
With this commit ...

Simply including the module will include the ::install class.
The ::install class will install dependencies on agent or master.

(A custom puppetserver_installed fact, defined by puppetlabs-resource_api,
which is a dependency of this module, is used to detect a master.)

Optionally, the ::install::agent and ::install::master classes can be declared
directly, allowing the user to specify their parameters ... if any.

Keep manifests/*.pp to allow for a transition to these classes.