### PR TITLE
(maint) Fix acceptance tests on fresh device config

### DIFF
--- a/spec/acceptance/ios_aaa_accounting_spec.rb
+++ b/spec/acceptance/ios_aaa_accounting_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper_acceptance'
 describe 'ios_aaa_accounting' do
   before(:all) do
     pp = <<-EOS
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
     ios_aaa_accounting { 'network default':
       accounting_service => 'network',
       accounting_list => 'default',

--- a/spec/acceptance/ios_aaa_authentication_spec.rb
+++ b/spec/acceptance/ios_aaa_authentication_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper_acceptance'
 describe 'ios_aaa_authentication' do
   before(:all) do
     pp = <<-EOS
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
     ios_aaa_authentication { 'ppp default':
       authentication_list_set => 'ppp',
       authentication_list => 'default',

--- a/spec/acceptance/ios_aaa_authorization_spec.rb
+++ b/spec/acceptance/ios_aaa_authorization_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper_acceptance'
 describe 'ios_aaa_authorization' do
   before(:all) do
     pp = <<-EOS
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
     ios_aaa_authorization { 'auth-proxy default':
       authorization_service => 'auth-proxy',
       authorization_list => 'default',

--- a/spec/acceptance/ios_aaa_session_id_spec.rb
+++ b/spec/acceptance/ios_aaa_session_id_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper_acceptance'
 describe 'ios_session_id' do
   it 'apply session_id common' do
     pp = <<-EOS
-     ios_aaa_session_id { 'default':
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
+    ios_aaa_session_id { 'default':
       session_id_type => 'common',
     }
     EOS

--- a/spec/acceptance/ios_config_spec.rb
+++ b/spec/acceptance/ios_config_spec.rb
@@ -4,8 +4,8 @@ describe 'ios_config' do
 
   before(:all) do
     result = run_resource('network_dns')
-    actual = result.match(%r{domain => '(\w.*)'})[1]
-    domain_name = actual unless actual.nil?
+    actual = result.match(%r{domain => '(\w.*)'})
+    domain_name = actual[1] unless actual.nil?
   end
 
   it 'just "command" set' do

--- a/spec/acceptance/network_dns_spec.rb
+++ b/spec/acceptance/network_dns_spec.rb
@@ -4,8 +4,8 @@ describe 'network_dns' do
 
   before(:all) do
     result = run_resource('network_dns')
-    actual = result.match(%r{domain => '(\w.*)'})[1]
-    domain_name = actual unless actual.nil?
+    actual = result.match(%r{domain => '(\w.*)'})
+    domain_name = actual[1] unless actual.nil?
   end
 
   it 'set one way' do

--- a/spec/acceptance/radius_global_spec.rb
+++ b/spec/acceptance/radius_global_spec.rb
@@ -4,6 +4,9 @@ describe 'radius_global' do
   before(:all) do
     # Set to known values
     pp = <<-EOS
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
     radius_global { "default":
       key => 'jim',
       key_format => 3,

--- a/spec/acceptance/radius_server_group_spec.rb
+++ b/spec/acceptance/radius_server_group_spec.rb
@@ -4,6 +4,9 @@ describe 'radius_server_group' do
   before(:all) do
     # Remove if already present
     pp = <<-EOS
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
     radius_server_group { "bill":
       ensure => 'absent',
     }

--- a/spec/acceptance/radius_server_spec.rb
+++ b/spec/acceptance/radius_server_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper_acceptance'
 describe 'radius_server' do
   before(:all) do
     pp = <<-EOS
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
     radius_server { "2.2.2.2":
       ensure => 'absent',
     }

--- a/spec/acceptance/tacacs_server_group_spec.rb
+++ b/spec/acceptance/tacacs_server_group_spec.rb
@@ -4,10 +4,13 @@ describe 'tacacs_server_group' do
   before(:all) do
     # Remove if already present, add test Vlan
     pp = <<-EOS
-  tacacs_server_group { "test1":
-    ensure => 'absent',
-  }
-  EOS
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
+    tacacs_server_group { "test1":
+      ensure => 'absent',
+    }
+    EOS
     make_site_pp(pp)
     run_device(allow_changes: true)
   end

--- a/spec/acceptance/tacacs_server_spec.rb
+++ b/spec/acceptance/tacacs_server_spec.rb
@@ -4,12 +4,15 @@ describe 'tacacs_server' do
   before(:all) do
     # Remove if already present
     pp = <<-EOS
-  tacacs_server { '4.3.2.1':
-    ensure => 'absent',
-  }
-  tacacs_server { 'test_tacacs_1':
-    ensure => 'absent',
-  }
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
+    tacacs_server { '4.3.2.1':
+      ensure => 'absent',
+    }
+    tacacs_server { 'test_tacacs_1':
+      ensure => 'absent',
+    }
     EOS
     make_site_pp(pp)
     run_device(allow_changes: true)


### PR DESCRIPTION
Fix acceptance tests such that there are no dependencies on
device config eg. 'aaa new model' or previous domain name