### PR TITLE
(FM-7737) Add enable secret to test pre-requisite

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -136,7 +136,7 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
         enable_cmd = { 'String' => 'enable', 'Match' => %r{|#$|>$} }
         prompt = send_command(connection, enable_cmd, true)
         # Do not send password unless requried
-        unless prompt =~ %r{#$}
+        unless prompt =~ %r{#$} || @enable_password.nil?
           # Turn off dump log to prevent leaking enable password
           options = connection.instance_variable_get(:@options)
           dump_log = options['Dump_log']

--- a/spec/acceptance/ios_aaa_accounting_spec.rb
+++ b/spec/acceptance/ios_aaa_accounting_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper_acceptance'
 describe 'ios_aaa_accounting' do
   before(:all) do
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     ios_aaa_accounting { 'network default':
       accounting_service => 'network',
       accounting_list => 'default',

--- a/spec/acceptance/ios_aaa_authentication_spec.rb
+++ b/spec/acceptance/ios_aaa_authentication_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper_acceptance'
 describe 'ios_aaa_authentication' do
   before(:all) do
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     ios_aaa_authentication { 'ppp default':
       authentication_list_set => 'ppp',
       authentication_list => 'default',

--- a/spec/acceptance/ios_aaa_authorization_spec.rb
+++ b/spec/acceptance/ios_aaa_authorization_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper_acceptance'
 describe 'ios_aaa_authorization' do
   before(:all) do
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     ios_aaa_authorization { 'auth-proxy default':
       authorization_service => 'auth-proxy',
       authorization_list => 'default',

--- a/spec/acceptance/ios_aaa_session_id_spec.rb
+++ b/spec/acceptance/ios_aaa_session_id_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper_acceptance'
 describe 'ios_session_id' do
   it 'apply session_id common' do
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     ios_aaa_session_id { 'default':
       session_id_type => 'common',
     }

--- a/spec/acceptance/radius_global_spec.rb
+++ b/spec/acceptance/radius_global_spec.rb
@@ -4,9 +4,6 @@ describe 'radius_global' do
   before(:all) do
     # Set to known values
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     network_vlan { "42":
       shutdown => true,
       ensure => present,

--- a/spec/acceptance/radius_server_group_spec.rb
+++ b/spec/acceptance/radius_server_group_spec.rb
@@ -4,9 +4,6 @@ describe 'radius_server_group' do
   before(:all) do
     # Remove if already present
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     radius_server_group { "bill":
       ensure => 'absent',
     }

--- a/spec/acceptance/radius_server_spec.rb
+++ b/spec/acceptance/radius_server_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper_acceptance'
 describe 'radius_server' do
   before(:all) do
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     radius_server { "2.2.2.2":
       ensure => 'absent',
     }

--- a/spec/acceptance/tacacs_server_group_spec.rb
+++ b/spec/acceptance/tacacs_server_group_spec.rb
@@ -4,9 +4,6 @@ describe 'tacacs_server_group' do
   before(:all) do
     # Remove if already present, add test Vlan
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     tacacs_server_group { "test1":
       ensure => 'absent',
     }

--- a/spec/acceptance/tacacs_server_spec.rb
+++ b/spec/acceptance/tacacs_server_spec.rb
@@ -4,9 +4,6 @@ describe 'tacacs_server' do
   before(:all) do
     # Remove if already present
     pp = <<-EOS
-    ios_config { "enable aaa":
-      command => 'aaa new-model'
-    }
     tacacs_server { '4.3.2.1':
       ensure => 'absent',
     }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -150,6 +150,17 @@ PP
         on host, 'systemctl restart  pe-puppetserver.service'
         # Regenerate the types
         on host, 'puppet generate types'
+        # set pre-requisites, aaa new-model and enable secret such that we don't get locked out of enable mode
+        pp = <<-EOS
+    ios_config { "enable password":
+      command => 'enable secret #{device_enable_password}'
+    }
+    ios_config { "enable aaa":
+      command => 'aaa new-model'
+    }
+        EOS
+        make_site_pp(pp)
+        run_device(allow_changes: true)
       end
     end
   end


### PR DESCRIPTION
It was found that 'aaa new-model' pre-requisite had the potential
to lock devices out of enable mode. Explicity adding the known
enable secret allows for enable privileged mode to be accessible.