### PR TITLE
(maint) Add an OS Family fact

### DIFF
--- a/lib/puppet/util/network_device/cisco_ios/device.rb
+++ b/lib/puppet/util/network_device/cisco_ios/device.rb
@@ -340,6 +340,8 @@ module Puppet::Util::NetworkDevice::Cisco_ios # rubocop:disable Style/ClassAndMo
       begin
         version_info = @connection.cmd('show version')
         raise Puppet::Error, 'Could not retrieve facts' unless version_info
+        facts['os'] = {}
+        facts['os']['family'] = version_info[%r{(.*Software)}]
         facts['hardwaremodel'] = version_info[%r{cisco\s+(\S+).+processor}i, 1]
         facts['hostname'] = version_info[%r{(\S+)\s+uptime}, 1]
         facts['serialnumber'] = version_info[%r{Processor board ID (\w*)}, 1]


### PR DESCRIPTION
An OS family fact will allow for differentation between IOS
and IOS XE devices