### PR TITLE
Update README: "Install dependencies" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Since a Puppet agent is not available for the Catalysts (and, seriously, who wou
 
 To install dependencies of the Cisco IOS module:
 
-1. Classify or apply the `cisco_ios` class on each master (master of masters, and if present, compile masters and replica master) that serves catalogs for this module.
-1. Classify or apply the `cisco_ios` class on each proxy Puppet agent that proxies for Cisco IOS devices.
+1. Classify or apply the `cisco_ios::server` class on each master (master of masters, and if present, compile masters and replica master) that serves catalogs for this module.
+2. Classify or apply the `cisco_ios::proxy` class on each proxy Puppet agent that proxies for Cisco IOS devices.
 
 Run puppet agent -t on the master(s) before using the module on the agent(s).
 


### PR DESCRIPTION
The README on the module local files say to apply the classes "cisco_ios::server" and "cisco_ios::proxy" to the puppet master and proxy agent, respectively, but the README on git say just "cisco_ios", which generates exceptions during the agent's run.