### PR TITLE
(maint) making enable_password optional

### DIFF
--- a/lib/puppet/transport/cisco_ios.rb
+++ b/lib/puppet/transport/cisco_ios.rb
@@ -29,7 +29,7 @@ module Puppet::Transport
       @config = connection_info
 
       create_connection
-      @enable_password = connection_info[:enable_password].unwrap
+      @enable_password = connection_info[:enable_password].unwrap if connection_info[:enable_password]
       @facts = facts(context)
       PuppetX::CiscoIOS::Utility.facts(@facts)
     end
@@ -87,7 +87,6 @@ module Puppet::Transport
         FileUtils.chmod 0o0640, @options['Dump_log']
       end
       @connection = Net::SSH::Telnet.new(@options)
-      @enable_password = config[:enable_password].unwrap
       @command_timeout = config[:command_timeout] || 120
       # IOS will page large results which breaks prompt search
       send_command(@connection, 'terminal length 0')

--- a/lib/puppet/transport/schema/cisco_ios.rb
+++ b/lib/puppet/transport/schema/cisco_ios.rb
@@ -25,7 +25,7 @@ EOS
       desc: 'The password to use for authenticating all connections to the device.',
     },
     enable_password: {
-      type: 'String',
+      type: 'Optional[String]',
       sensitive: true,
       desc: 'The password to use for entering into enable mode on the device.',
     },


### PR DESCRIPTION
Some devices are configured in away that a user defaults to privalidged mode which means there is no need to set an enable password.