### PR TITLE
(maint) acl and access conversion to match other providers

### DIFF
--- a/lib/puppet/provider/ios_access_list/cisco_ios.rb
+++ b/lib/puppet/provider/ios_access_list/cisco_ios.rb
@@ -2,7 +2,7 @@ require_relative '../../util/network_device/cisco_ios/device'
 require_relative '../../../puppet_x/puppetlabs/cisco_ios/utility'
 
 # Configure Access List on the device
-class Puppet::Provider::IosAccessList::IosAccessList
+class Puppet::Provider::IosAccessList::CiscoIos
   def self.commands_hash
     @commands_hash = PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/command.yaml')
   end
@@ -33,13 +33,13 @@ class Puppet::Provider::IosAccessList::IosAccessList
   end
 
   def commands_hash
-    Puppet::Provider::IosAccessList::IosAccessList.commands_hash
+    Puppet::Provider::IosAccessList::CiscoIos.commands_hash
   end
 
   def get(context)
     output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
     return [] if output.nil?
-    Puppet::Provider::IosAccessList::IosAccessList.instances_from_cli(output)
+    Puppet::Provider::IosAccessList::CiscoIos.instances_from_cli(output)
   end
 
   def set(context, changes)
@@ -59,7 +59,7 @@ class Puppet::Provider::IosAccessList::IosAccessList
   end
 
   def update(context, _name, should)
-    array_of_commands_to_run = Puppet::Provider::IosAccessList::IosAccessList.commands_from_instance(should)
+    array_of_commands_to_run = Puppet::Provider::IosAccessList::CiscoIos.commands_from_instance(should)
     array_of_commands_to_run.each do |command|
       context.transport.run_command_conf_t_mode(command)
     end
@@ -67,7 +67,7 @@ class Puppet::Provider::IosAccessList::IosAccessList
 
   def delete(context, _name, is)
     is[:ensure] = 'absent'
-    array_of_commands_to_run = Puppet::Provider::IosAccessList::IosAccessList.commands_from_instance(is)
+    array_of_commands_to_run = Puppet::Provider::IosAccessList::CiscoIos.commands_from_instance(is)
     array_of_commands_to_run.each do |command|
       context.transport.run_command_conf_t_mode(command)
     end

--- a/spec/unit/puppet/provider/ios_access_list/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_access_list/cisco_ios_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 module Puppet::Provider::IosAccessList; end
-require 'puppet/provider/ios_access_list/ios'
+require 'puppet/provider/ios_access_list/cisco_ios'
 
-RSpec.describe Puppet::Provider::IosAccessList::IosAccessList do
+RSpec.describe Puppet::Provider::IosAccessList::CiscoIos do
   def self.load_test_data
     PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/test_data.yaml', false)
   end

--- a/spec/unit/puppet/provider/ios_acl_entry/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_acl_entry/cisco_ios_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 module Puppet::Provider::IosAclEntry; end
-require 'puppet/provider/ios_acl_entry/ios'
+require 'puppet/provider/ios_acl_entry/cisco_ios'
 
-RSpec.describe Puppet::Provider::IosAclEntry::IosAclEntry do
+RSpec.describe Puppet::Provider::IosAclEntry::CiscoIos do
   def self.load_test_data
     PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/test_data.yaml', false)
   end


### PR DESCRIPTION
The work done on acls and access lists overlapped with the transport and naming conversion work and the conversion was never done.

This change will bring the acl and access list providers inline with the others and enforce the type requirements.