### PR TITLE
(FM-7750) - Network Trunk update to account for XE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,7 +1029,7 @@ Note that this is *not* an exhaustive list of supported devices, but rather the 
 | network_dns                | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
 | network_interface          | ok*                  | ok*  | ok*                  | ok   | ok                   | ok                   | ok                   |
 | network_snmp               | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
-| network_trunk              | ok*                  | -    | ok                   | -    | ok                   | ok                   | ok                   |
+| network_trunk              | ok*                  | ok*  | ok                   | ok*  | ok                   | ok                   | ok                   |
 | network_vlan               | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
 | ntp_auth_key               | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
 | ntp_config                 | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
@@ -1083,6 +1083,10 @@ This device does not have native trunking. It does not support the following att
 
 * ensure
 * encapsulation
+
+##### XE OS 
+
+This device type only supports a single method of encapsulation, `802.1q`, and as such the attribute to set it is not supported.
 
 #### ntp_server
 

--- a/lib/puppet/provider/network_trunk/command.yaml
+++ b/lib/puppet/provider/network_trunk/command.yaml
@@ -28,6 +28,7 @@ attributes:
       can_have_no_match: 'true'
     exclusions:
     - device: '2960'
+    - os_family: '^(?!.*IOS-XE Software).*$'
   mode:
     default:
       get_value: '.*(?:(?:Administrative Mode: )(?:(?<mode>[^\\n]*)\\n)).*'

--- a/spec/acceptance/network_trunk_spec.rb
+++ b/spec/acceptance/network_trunk_spec.rb
@@ -38,7 +38,7 @@ describe 'network_trunk' do
       ensure => 'present',
       encapsulation => 'dot1q',
       mode => 'dynamic_desirable',
-      untagged_vlan => 1,
+      untagged_vlan => 42,
     }
     EOS
     make_site_pp(pp)
@@ -51,7 +51,7 @@ describe 'network_trunk' do
     # Not set/read on a 2960
     expect(result).to match(%r{encapsulation.*dot1q}) if result =~ %r{encapsulation.}
     expect(result).to match(%r{mode.*dynamic_desirable})
-    expect(result).to match(%r{untagged_vlan.*1})
+    expect(result).to match(%r{untagged_vlan.*42})
     expect(result).to match(%r{ensure.*present})
   end
 


### PR DESCRIPTION
- Encapsulation excluded for all XE devices as only a single encapsulation type is supported
- Port set in test changed to vlan42