### PR TITLE
(maint) updating the error and warning checks

### DIFF
--- a/spec/acceptance/network_interface_spec.rb
+++ b/spec/acceptance/network_interface_spec.rb
@@ -18,7 +18,7 @@ describe 'network_interface' do
     network_interface { 'Vlan42':
       enable => true,
       description => 'This is a test interface.',
-      mtu => 128,
+      mtu => 1501,
     }
     EOS
     make_site_pp(pp)
@@ -30,7 +30,7 @@ describe 'network_interface' do
     expect(result).to match(%r{Vlan42.*})
     expect(result).to match(%r{description.*This is a test interface})
     if result =~ %r{mtu.*}
-      expect(result).to match(%r{mtu.*128})
+      expect(result).to match(%r{mtu.*1501})
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -69,8 +69,8 @@ def run_device(options = { allow_changes: true })
     if options[:allow_changes] == false
       expect(result.stdout).not_to match(%r{^Notice: /Stage\[main\]})
     end
-    expect(result.stderr).not_to match(%r{^Error:})
-    expect(result.stderr).not_to match(%r{^Warning:})
+    expect(result.stderr).not_to match(%r{Error:})
+    expect(result.stderr).not_to match(%r{Warning:})
   end
 end
 


### PR DESCRIPTION
Previously it was only checking line starts with `Error:` or `Warning:` - but colour output in the device runs meant the line started with a colour hex.

This change will highlight areas of the test which are failing across devices.

Also updating the MTU value as some older devices has a lowest bound of 1501.