### PR TITLE
FM-7753 XE functionality for ntp_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,7 +1032,7 @@ Note that this is *not* an exhaustive list of supported devices, but rather the 
 | network_trunk              | ok*                  | -    | ok                   | -    | ok                   | ok                   | ok                   |
 | network_vlan               | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
 | ntp_auth_key               | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
-| ntp_config                 | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
+| ntp_config                 | ok                   | ok   | ok                   | ok   | ok                   | ok                   | ok                   |
 | ntp_server                 | ok                   | -    | ok*                  | -    | ok                   | ok*                  | ok                   |
 | port_channel               | ok                   | -    | ok*                  | -    | ok*                  | ok                   | ok                   |
 | radius                     | not supported by IOS | -    | not supported by IOS | -    | not supported by IOS | not supported by IOS | not supported by IOS |

--- a/spec/acceptance/ntp_config_spec.rb
+++ b/spec/acceptance/ntp_config_spec.rb
@@ -5,12 +5,20 @@ describe 'ntp_config' do
     # Remove if already present, add test Vlan
     pp = <<-EOS
     network_vlan { "42":
-      shutdown => true,
+      shutdown => false,
       ensure => present,
     }
     network_vlan { "43":
-      shutdown => true,
+      shutdown => false,
       ensure => present,
+    }
+    network_interface { 'Vlan42':
+      enable => true,
+      description => 'vlan42',
+    }
+    network_interface { 'Vlan43':
+      enable => true,
+      description => 'vlan43',
     }
     ntp_config { 'default':
       authenticate => false,


### PR DESCRIPTION
ntp_config test setup needs to set the interface vlan as well as the network_vlan