### PR TITLE
(maint) Fix for NTP Server test

### DIFF
--- a/spec/acceptance/ntp_server_spec.rb
+++ b/spec/acceptance/ntp_server_spec.rb
@@ -5,6 +5,10 @@ describe 'ntp_server' do
   before(:all) do
     # Remove if already present
     pp = <<-EOS
+    network_interface { 'Vlan42':
+      enable => true,
+      description => 'vlan42',
+    }
     network_vlan { "42":
       shutdown => true,
       ensure => present,
@@ -53,7 +57,7 @@ describe 'ntp_server' do
     # As documented in readme, it is possible that an ntp_server with a different source_interface
     # may create a new entry. As resource gets all entries, and this seems to be Cisco functionality,
     # iterate over entries until appropriate entry is found, check assertions.
-    results = YAML.safe_load(run_resource('ntp_server --to_yaml'), [Symbol])
+    results = YAML.safe_load(run_resource('ntp_server --to_yaml', nil, false), [Symbol])
     found_edited = false
     results['ntp_server'].each do |result|
       next unless result.first.to_s == '1.2.3.4' && result[1]['key'] == 94

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -44,11 +44,16 @@ def run_device(options = { allow_changes: true })
   expect(result[0]).not_to match %r{Warning:}
 end
 
-def run_resource(resource_type, resource_title = nil)
+def run_resource(resource_type, resource_title = nil, verbose = true)
+  verbose_args = if verbose == true
+                   '--verbose --trace --debug'
+                 else
+                   ''
+                 end
   result = if resource_title
-             Open3.capture2e("bundle exec puppet device --resource #{resource_type} #{resource_title} #{COMMON_ARGS} --verbose --trace --debug")
+             Open3.capture2e("bundle exec puppet device --resource #{resource_type} #{resource_title} #{COMMON_ARGS} #{verbose_args}")
            else
-             Open3.capture2e("bundle exec puppet device --resource #{resource_type} #{COMMON_ARGS} --verbose --trace --debug")
+             Open3.capture2e("bundle exec puppet device --resource #{resource_type} #{COMMON_ARGS} #{verbose_args}")
            end
   result[0]
 end


### PR DESCRIPTION
Now that we execute locally, we pick up all debug.
One of our test fixtures was picking up all debug output, but we wished to parse only the Puppet device output as yaml.
This commit allows for the verbose, debug, trace option string to be set to an empty string (ie. not set) if desired.