### PR TITLE
(maint) SNMP Notification acceptance test fix

### DIFF
--- a/spec/acceptance/snmp_notification_spec.rb
+++ b/spec/acceptance/snmp_notification_spec.rb
@@ -39,6 +39,6 @@ describe 'snmp_notification' do
     run_device(allow_changes: false)
     # Check puppet resource
     result = run_resource('snmp_notification', 'stpx')
-    expect(result).not_to match(%r{enable})
+    expect(result).not_to match(%r{enable.*=>})
   end
 end


### PR DESCRIPTION
As we now return all debug output to the matcher, only try to match when the field is in a Puppet data structure