### PR TITLE
(maint) Fix for TACACS Global test

### DIFF
--- a/lib/puppet/provider/tacacs_global/command.yaml
+++ b/lib/puppet/provider/tacacs_global/command.yaml
@@ -15,7 +15,7 @@ attributes:
       set_value: 'tacacs-server key <key_format>'
   source_interface:
     default:
-      get_value: 'ip tacacs source-interface (?<rsource_interface>[^\s]+)'
+      get_value: '^ip tacacs source-interface (?<rsource_interface>[^\s]+)'
       set_value: 'ip tacacs source-interface <source_interface>'
       unset_value: 'no ip tacacs source-interface <source_interface>'
   timeout:

--- a/spec/acceptance/tacacs_global_spec.rb
+++ b/spec/acceptance/tacacs_global_spec.rb
@@ -47,7 +47,7 @@ describe 'tacacs_global' do
       expect(result).to match(%r{key.*bill})
       expect(result).to match(%r{key_format.*4})
     end
-    expect(result).to match(%r{source_interface.*Vlan43}) if result =~ %r{source_interface}
+    expect(result).to match(%r{source_interface.*=> ['Vlan43']}) if result =~ %r{source_interface.*=>}
     # Due to Cisco bug as described at
     # https://supportforums.cisco.com/t5/aaa-identity-and-nac/tacacs-timeout-value-ignored/td-p/346109
     # The timeout may not apply and may remain at default


### PR DESCRIPTION
Source interface does not always show, because IOS.
The check needed updated now we output all debug.