### PR TITLE
(maint) Fix for IOS STP Global test

### DIFF
--- a/lib/puppet/provider/ios_stp_global/command.yaml
+++ b/lib/puppet/provider/ios_stp_global/command.yaml
@@ -87,7 +87,7 @@ attributes:
       can_have_no_match: 'true'
   portfast:
     default:
-      get_value: '(?:[^ ]spanning-tree portfast )(?<portfast>.[^\\n]*)'
+      get_value: '(?:[^ ]spanning-tree portfast )(?:edge )*(?<portfast>.[^\\n]*)'
       set_value: 'spanning-tree portfast <portfast>'
       can_have_no_match: 'true'
   uplinkfast:


### PR DESCRIPTION
The 6503 accepts the portfast bpduguard default command.
However it stores this in config as an 'edge' option.
Amend the regular expression to capture this.