### PR TITLE
(maint) Fix for Tacas Global Test

### DIFF
--- a/spec/acceptance/tacacs_global_spec.rb
+++ b/spec/acceptance/tacacs_global_spec.rb
@@ -47,7 +47,7 @@ describe 'tacacs_global' do
       expect(result).to match(%r{key.*bill})
       expect(result).to match(%r{key_format.*4})
     end
-    expect(result).to match(%r{source_interface.*=> ['Vlan43']}) if result =~ %r{source_interface.*=>}
+    expect(result).to match(%r{source_interface.*=> \['Vlan43'\]}) if result =~ %r{source_interface.*=>}
     # Due to Cisco bug as described at
     # https://supportforums.cisco.com/t5/aaa-identity-and-nac/tacacs-timeout-value-ignored/td-p/346109
     # The timeout may not apply and may remain at default


### PR DESCRIPTION
The regex in the test’s seems to be getting confused at the square brackets. Adding back ticks looks to fix it.