### PR TITLE
(maint) Add 4948 exclusion to Radius Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,7 +1061,7 @@ Note that this is *not* an exhaustive list of supported devices, but rather the 
 | port_channel               | ok*                  | ok*  | ok*                  | ok*  | ok*                  | ok*                  | ok                   |
 | radius                     | not supported by IOS | -    | not supported by IOS | -    | not supported by IOS | not supported by IOS | not supported by IOS |
 | radius_global*             | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
-| radius_server              | ok                   | -    | not supported        | -    | ok                   | ok                   | not supported        |
+| radius_server              | ok                   | -    | not supported        | -    | ok                   | not supported        | not supported        |
 | radius_server_group        | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
 | search_domain              | use network_dns      | -    | use network_dns      | -    | use network_dns      | use network_dns      | use network_dns      |
 | snmp_community             | ok                   | -    | ok                   | -    | ok                   | ok                   | ok                   |
@@ -1164,6 +1164,8 @@ The IOS operating system does not support:
 #### radius_server
 
 ##### 3750
+
+##### 4948
 
 ##### 6503
 

--- a/lib/puppet/provider/radius_server/command.yaml
+++ b/lib/puppet/provider/radius_server/command.yaml
@@ -9,6 +9,7 @@ set_values:
   default: 'radius server <name>'
 exclusions:
 - device: '3750'
+- device: '4948'
 - device: '6503'
 attributes:
   name:

--- a/spec/acceptance/radius_server_spec.rb
+++ b/spec/acceptance/radius_server_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'radius_server' do
   before(:all) do
-    skip "this device #{device_model} does not support radius server" if ['3750', '6503'].include?(device_model)
+    skip "this device #{device_model} does not support radius server" if ['3750', '6503', '4948'].include?(device_model)
     pp = <<-EOS
     radius_server { "2.2.2.2":
       ensure => 'absent',


### PR DESCRIPTION
Tests highlight that the Radius Server is not compatible with the test 4948.
Add exclusion to the provider and test spec.