### PR TITLE
(FM-7757) Add IOS_radius_global type and provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Please see the netdev_stdlib docs https://github.com/puppetlabs/netdev_stdlib/bl
 * [`ios_aaa_new_model`](#ios_aaa_new_model): Enable aaa new model on device
 * [`ios_aaa_session_id`](#ios_aaa_session_id): Configure aaa session id on device
 * [`ios_config`](#ios_config): Execute an arbitrary configuration against the cisco_ios device with or without a check for idempotency.
+* [`ios_radius_global`](#ios_radius_global): Extends the radius_global type.
 * [`ios_stp_global`](#ios_stp_global): Manages the Cisco Spanning-tree Global configuration resource.
 
 #### cisco_ios
@@ -877,6 +878,22 @@ Data type: `String`
 
 Name. Made up of access_list and the entry with an underscore seperator. eg. list42_10 is from access_list list42 and entry 10.
 
+### ios_radius_global
+
+Extends the radius_global type.
+
+#### Properties
+
+The following properties are available in the `ios_radius_global` type.
+
+##### `attributes`
+
+Data type: `Optional[Array[Tuple[Integer, String]]]`
+
+An array of [attribute number, attribute options] pairs
+
+See `radius_global` for other available fields
+
 ### ios_stp_global
 
 Manages the Cisco Spanning-tree Global configuration resource.
@@ -1046,6 +1063,7 @@ We support devices across the Catalyst family — both legacy IOS and IOS-XE. We
 | banner                     | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | domain_name                | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      |
 | ios_config                 | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
+| ios_radius_global          | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | ios_stp_global             | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok                   |
 | name_server                | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      |
 | network_dns                | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |

--- a/lib/puppet/provider/ios_radius_global/cisco_ios.rb
+++ b/lib/puppet/provider/ios_radius_global/cisco_ios.rb
@@ -1,0 +1,72 @@
+require_relative '../../util/network_device/cisco_ios/device'
+require_relative '../../../puppet_x/puppetlabs/cisco_ios/utility'
+require_relative '../radius_global/cisco_ios'
+
+# Configure the domain name of the device
+class Puppet::Provider::IosRadiusGlobal::CiscoIos
+  def self.commands_hash
+    local_commands_hash = PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/command.yaml')
+    radius_global_commands_hash = PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/../radius_global/command.yaml')
+    @commands_hash = local_commands_hash.merge(radius_global_commands_hash) { |_key, oldval, newval| (oldval.to_a + newval.to_a).to_h }
+  end
+
+  def self.instances_from_cli(output)
+    new_instance_fields = []
+    new_instance = {}
+    new_instance[:attributes] = PuppetX::CiscoIOS::Utility.parse_multiples(output, commands_hash, 'attributes', 0)
+    new_instance = new_instance.merge(Puppet::Provider::RadiusGlobal::CiscoIos.instances_from_cli(output).first)
+    new_instance.delete_if { |_k, v| v.nil? }
+    new_instance_fields << new_instance
+    new_instance_fields
+  end
+
+  def self.commands_from_instance(instance)
+    commands = []
+    if instance[:remove_attributes]
+      remove_instance = { name: (instance[:name]).to_s, attributes: instance[:remove_attributes] }
+      remove_commands = PuppetX::CiscoIOS::Utility.set_tuple_values(remove_instance, commands_hash, 'attributes', 'attribute_id', 'attribute_string')
+      remove_commands.each do |remove_command|
+        commands << "no #{remove_command}"
+      end
+      instance.delete(:remove_attributes)
+    end
+    commands.concat(PuppetX::CiscoIOS::Utility.set_tuple_values(instance, commands_hash, 'attributes', 'attribute_id', 'attribute_string'))
+    commands += Puppet::Provider::RadiusGlobal::CiscoIos.commands_from_instance(instance)
+    commands
+  end
+
+  def commands_hash
+    Puppet::Provider::IosRadiusGlobal::CiscoIos.commands_hash
+  end
+
+  def get(context, _names = nil)
+    output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
+    return [] if output.nil?
+    return_value = Puppet::Provider::IosRadiusGlobal::CiscoIos.instances_from_cli(output)
+    PuppetX::CiscoIOS::Utility.enforce_simple_types(context, return_value)
+  end
+
+  def set(context, changes)
+    changes.each do |name, change|
+      should = change[:should]
+      if change[:is][:attributes]
+        should[:remove_attributes] = change[:is][:attributes] - should[:attributes]
+        should[:attributes] = should[:attributes] - change[:is][:attributes]
+      end
+      context.updating(name) do
+        update(context, name, should)
+      end
+    end
+  end
+
+  def update(context, _name, should)
+    array_of_commands_to_run = Puppet::Provider::IosRadiusGlobal::CiscoIos.commands_from_instance(should)
+    array_of_commands_to_run.each do |command|
+      context.transport.run_command_conf_t_mode(command)
+    end
+  end
+
+  def canonicalize(_context, resources)
+    resources
+  end
+end

--- a/lib/puppet/provider/ios_radius_global/command.yaml
+++ b/lib/puppet/provider/ios_radius_global/command.yaml
@@ -1,0 +1,6 @@
+attributes:
+  attributes:
+    default:
+      get_value: '.*(?:(?:radius-server attribute (?!list)(?<attribute_id>\S*)) (?<attribute_string>[^\\n]*)\\n)'
+      set_value: 'radius-server attribute <attribute_id> <attribute_string>'
+      can_have_no_match: 'true'

--- a/lib/puppet/type/ios_radius_global.rb
+++ b/lib/puppet/type/ios_radius_global.rb
@@ -1,0 +1,47 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'ios_radius_global',
+  docs: 'Configure IOS global RADIUS settings',
+  features: ['canonicalize', 'simple_get_filter'] + (Puppet::Util::NetworkDevice.current.nil? ? [] : ['remote_resource']),
+  attributes: {
+    name: {
+      type:       'String',
+      desc:       'Resource name, not used to manage the device',
+      behaviour:  :namevar,
+      default:    'default',
+    },
+    enable: {
+      type:      'Optional[Boolean]',
+      desc:      'Enable or disable RADIUS functionality [true|false]',
+    },
+    attributes: {
+      type:      'Optional[Array[Tuple[Integer, String]]]',
+      desc:      'An array of [attribute number, attribute options] pairs',
+    },
+    key: {
+      type:      'Optional[String]',
+      desc:      'Encryption key (plaintext or in hash form depending on key_format)',
+    },
+    key_format: {
+      type:      'Optional[Integer]',
+      desc:      'Encryption key format [0-7]',
+    },
+    retransmit_count: {
+      type:      'Optional[Variant[Integer, Enum["unset"]]]',
+      desc:      "How many times to retransmit or 'unset' (Cisco Nexus only)",
+    },
+    source_interface: {
+      type:      'Optional[Array[String]]',
+      desc:      'The source interface used for RADIUS packets (array of strings for multiple).',
+    },
+    timeout: {
+      type:      'Optional[Variant[Integer, Enum["unset"]]]',
+      desc:      "Number of seconds before the timeout period ends or 'unset' (Cisco Nexus only)",
+    },
+    vrf: {
+      type:      'Optional[Array[String]]',
+      desc:      'The VRF associated with source_interface (array of strings for multiple).',
+    },
+  },
+)

--- a/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
+++ b/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
@@ -391,6 +391,9 @@ module PuppetX::CiscoIOS
       trunk_mode_output
     end
 
+    # Parses tuple values
+    # convert_position_to_integer converts any value at array position 'x' to an integer
+    # eg. ['5', 'test_value'] with convert_position_to_integer 0 will return [5, 'test_value']
     def self.parse_multiples(output, commands_hash, attribute, convert_position_to_integer = nil)
       return_value = output.scan(%r{#{PuppetX::CiscoIOS::Utility.attribute_value_foraged_from_command_hash(commands_hash, attribute, 'get_value')}})
       unless convert_position_to_integer.nil?

--- a/spec/acceptance/ios_radius_global_spec.rb
+++ b/spec/acceptance/ios_radius_global_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper_acceptance'
+
+describe 'ios_radius_global' do
+  before(:all) do
+    # Set to known values
+    pp = <<-EOS
+    network_vlan { "42":
+      shutdown => true,
+      ensure => present,
+    }
+    network_vlan { "43":
+      shutdown => true,
+      ensure => present,
+    }
+    ios_radius_global { "default":
+      key => 'jim',
+      key_format => 3,
+      retransmit_count => 50,
+      source_interface => ['Vlan42'],
+      timeout => 50,
+      attributes => []
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+  end
+
+  it 'edit ios_radius_global' do
+    pp = <<-EOS
+    ios_radius_global { "default":
+      key => 'bill',
+      key_format => 4,
+      retransmit_count => 60,
+      source_interface => ['Vlan43'],
+      timeout => 60,
+      attributes => [[6, 'on-for-login-auth'], [6, 'support-multiple'], [8, 'include-in-access-req'], [25, 'access-request include']],
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_radius_global', 'default')
+    expect(result).to match(%r{default.*})
+    # Has a key, encrypted by default on 2960
+    if result =~ %r{key_format.*7}
+      expect(result).to match(%r{key.*})
+    else
+      # Plaintext
+      expect(result).to match(%r{key.*bill})
+      expect(result).to match(%r{key_format.*4})
+    end
+    expect(result).to match(%r{retransmit_count.*60})
+    expect(result).to match(%r{source_interface.*Vlan43})
+    expect(result).to match(%r{timeout.*60})
+    expect(result).to match(%r{6, 'on-for-login-auth'})
+    expect(result).to match(%r{6, 'support-multiple'})
+    expect(result).to match(%r{8, 'include-in-access-req'})
+    expect(result).to match(%r{25, 'access-request include'})
+  end
+
+  it 'edit ios_radius_global attributes' do
+    pp = <<-EOS
+    ios_radius_global { "default":
+      key => 'bill',
+      key_format => 4,
+      retransmit_count => 60,
+      source_interface => ['Vlan43'],
+      timeout => 60,
+      attributes => [[8, 'include-in-access-req'], [25, 'access-request include'], [31, 'mac format ietf']],
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_radius_global', 'default')
+    expect(result).to match(%r{default.*})
+    expect(result).to match(%r{8, 'include-in-access-req'})
+    expect(result).to match(%r{25, 'access-request include'})
+    expect(result).to match(%r{31, 'mac format ietf'})
+  end
+
+  it 'remove ios_radius_global attributes' do
+    pp = <<-EOS
+    ios_radius_global { "default":
+      key => 'bill',
+      key_format => 4,
+      retransmit_count => 60,
+      source_interface => ['Vlan43'],
+      timeout => 60,
+      attributes => [],
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_radius_global', 'default')
+    expect(result).to match(%r{default.*})
+    expect(result).not_to match(%r{attributes =>})
+  end
+end

--- a/spec/unit/puppet/provider/ios_radius_global/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_radius_global/cisco_ios_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+module Puppet::Provider::IosRadiusGlobal; end
+require 'puppet/provider/ios_radius_global/cisco_ios'
+
+RSpec.describe Puppet::Provider::IosRadiusGlobal::CiscoIos do
+  def self.load_test_data
+    radius_yaml = PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/../radius_global/test_data.yaml', false)
+    local_yaml = PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/test_data.yaml', false)
+    combined_tests = radius_yaml
+    combined_tests['default']['read_tests'] = radius_yaml['default']['read_tests'].merge(local_yaml['default']['read_tests'])
+    combined_tests['default']['update_tests'] = radius_yaml['default']['update_tests'].merge(local_yaml['default']['update_tests'])
+    combined_tests
+  end
+
+  it_behaves_like 'resources parsed from cli'
+  it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
+end

--- a/spec/unit/puppet/provider/ios_radius_global/test_data.yaml
+++ b/spec/unit/puppet/provider/ios_radius_global/test_data.yaml
@@ -1,0 +1,32 @@
+---
+default:
+  read_tests:
+    "radius global with attributes":
+      cli: "radius-server attribute 6 on-for-login-auth\nradius-server attribute 6 support-multiple\nradius-server attribute 55 include-in-acct-req\nradius-server attribute list test\n!\nradius-server attribute 31 mac format ietf\nradius-server retransmit 50\nradius-server timeout 50\nradius-server key 2\nip radius source-interface Vlan2 \n"
+      expectations:
+      - :name: 'default'
+        :key_format: 2
+        :retransmit_count: 50
+        :source_interface: ['Vlan2']
+        :timeout: 50
+        :attributes: [[6, 'on-for-login-auth'], [6, 'support-multiple'], [55, 'include-in-acct-req'], [31, 'mac format ietf']]
+  update_tests:
+    "radius global, key_format 2 key jim, attributes":
+      commands:
+      - "no radius-server attribute 6 on-for-login-auth"
+      - "no radius-server attribute 6 support-multiple"
+      - "radius-server attribute 55 include-in-acct-req"
+      - "radius-server attribute 31 mac format ietf"
+      - "radius-server key 2 jim"
+      - "radius-server retransmit 50"
+      - "ip radius source-interface Vlan2"
+      - "radius-server timeout 50"
+      instance:
+        :name: 'default'
+        :key: 'jim'
+        :key_format: 2
+        :retransmit_count: 50
+        :source_interface: ['Vlan2']
+        :attributes: [[55, 'include-in-acct-req'], [31, 'mac format ietf']]
+        :remove_attributes: [[6, 'on-for-login-auth'], [6, 'support-multiple']]
+        :timeout: 50


### PR DESCRIPTION
This type and provider expands the existing radius_global type and provider to allow for radius server attributes to be set, as per customer request.