### PR TITLE
(maint) Update the connection prompt to match on confirmation prompts

### DIFF
--- a/lib/puppet/transport/command.yaml
+++ b/lib/puppet/transport/command.yaml
@@ -1,6 +1,6 @@
 ---
 default:
-  connect_prompt: '[#>]\s?\z'
+  connect_prompt: '[#>\]]\s?\z'
   access_denied: '.*Access denied'
   unknown_command: '^.*% Unknown command.*$'
   invalid_input:  '^.*% Invalid input.*$'


### PR DESCRIPTION
Adds ']' to match on conformation prompts such as aaa new-model