### PR TITLE
(FM-8181) - Ios Network Trunk created

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Please see the netdev_stdlib docs https://github.com/puppetlabs/netdev_stdlib/bl
 * [`ios_aaa_session_id`](#ios_aaa_session_id): Configure aaa session id on device
 * [`ios_config`](#ios_config): Execute an arbitrary configuration against the cisco_ios device with or without a check for idempotency.
 * [`ios_radius_global`](#ios_radius_global): Extends the radius_global type.
+* [`ios_network_trunk`](#ios_network_trunk): Ethernet logical (switch-port) interface. Configures VLAN trunking.
 * [`ios_stp_global`](#ios_stp_global): Manages the Cisco Spanning-tree Global configuration resource.
 
 #### cisco_ios
@@ -906,6 +907,73 @@ An array of [attribute number, attribute options] pairs
 
 
 See `radius_global` for other available fields
+
+#### ios_network_trunk
+
+Ethernet logical (switch-port) interface.  Configures VLAN trunking. Extension of network_trunk.
+
+
+##### Properties
+
+The following properties are available in the `ios_network_trunk` type.
+
+###### `access_vlan`
+
+Data type: `Optional[Variant[Integer[0, 4095], Boolean[false]]`
+
+The VLAN to set when the interface is in access mode. Setting it to false will revert it to the default value.
+
+Examples:
+```
+access_vlan => 405
+```
+```
+access_vlan => false
+```
+
+###### `voice_vlan`
+
+Data type: `Optional[Variant[Integer[0, 4095], Enum["dot1p", "none", "untagged"], Boolean[false]]]`
+
+Sets how voice traffic should be treated by the access port. Setting it to false will revert it to the default value.
+
+Examples:
+```
+access_vlan => 221
+```
+```
+access_vlan => 'dot1p'
+```
+
+###### `allowed_vlans`
+
+Data type: `Optional[Variant[Enum["all", "none"], Tuple[Enum["add", "remove", "except"], String], String, Boolean[false]]]`
+
+Sets which VLANs the access port will use when trunking is enabled. Setting it to false will revert it to the default value.
+
+Examples:
+```
+access_vlan => '101-202'
+```
+```
+access_vlan => 'none'
+```
+```
+access_vlan => ['except', '204-301']
+```
+
+###### `switchport_nonegotiate`
+
+Data type: `Optional[Boolean]`
+
+When set, prevents the port from sending DTP (Dynamic Trunk Port) messages. Set automatically to true while in 'access mode' and cannot be set in 'dynamic_*' mode.
+
+Examples:
+```
+access_vlan => true
+```
+
+See `network_trunk` for other availible fields.
 
 ### ios_stp_global
 

--- a/lib/puppet/provider/ios_network_trunk/cisco_ios.rb
+++ b/lib/puppet/provider/ios_network_trunk/cisco_ios.rb
@@ -1,0 +1,128 @@
+require 'puppet/util/network_device/cisco_ios/device'
+require_relative '../../../puppet_x/puppetlabs/cisco_ios/utility'
+require_relative '../network_trunk/cisco_ios'
+
+# Network Trunk Puppet Provider for Cisco IOS devices
+class Puppet::Provider::IosNetworkTrunk::CiscoIos
+  def self.commands_hash
+    local_commands_hash = PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/command.yaml')
+    network_trunk_commands_hash = PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/../network_trunk/command.yaml')
+    @commands_hash = local_commands_hash.merge(network_trunk_commands_hash) { |_key, oldval, newval| (oldval.to_a + newval.to_a).to_h }
+  end
+
+  def self.instance_from_cli(output, interface_name)
+    new_instance = PuppetX::CiscoIOS::Utility.parse_resource(output, commands_hash)
+    new_instance[:name] = interface_name
+    new_instance[:mode] = PuppetX::CiscoIOS::Utility.convert_network_trunk_mode_cli(new_instance[:mode])
+    new_instance.delete_if { |_k, v| v.nil? }
+    new_instance[:ensure] = if new_instance[:ensure] || new_instance.size > 1
+                              'present'
+                            else
+                              'absent'
+                            end
+    new_instance
+  end
+
+  def self.commands_from_instance(property_hash)
+    commands_array = []
+    ensure_command = if PuppetX::CiscoIOS::Utility.attribute_safe_to_run(commands_hash, 'ensure')
+                       PuppetX::CiscoIOS::Utility.attribute_value_foraged_from_command_hash(commands_hash, 'ensure', 'set_value')
+                     else
+                       ''
+                     end
+    if property_hash[:ensure] == 'absent'
+      # delete with a 'no'
+      ensure_command = PuppetX::CiscoIOS::Utility.insert_attribute_into_command_line(ensure_command, 'state', 'no', false)
+      commands_array.push(ensure_command) if ensure_command != ''
+    else
+      ensure_command = PuppetX::CiscoIOS::Utility.insert_attribute_into_command_line(ensure_command, 'state', '', false)
+      commands_array.push(ensure_command.strip) if ensure_command != ''
+      unless property_hash[:mode].nil?
+        property_hash[:mode] = PuppetX::CiscoIOS::Utility.convert_network_trunk_mode_modelled(property_hash[:mode])
+      end
+      unless property_hash[:allowed_vlans].nil?
+        property_hash[:allowed_vlans] = Puppet::Provider::IosNetworkTrunk::CiscoIos.array_to_string(property_hash[:allowed_vlans])
+      end
+      property_hash.each do |key, _value|
+        property_hash[key] = Puppet::Provider::IosNetworkTrunk::CiscoIos.false_to_unset(property_hash[key])
+      end
+      commands_array += PuppetX::CiscoIOS::Utility.build_commmands_from_attribute_set_values(property_hash, commands_hash)
+    end
+    commands_array
+  end
+
+  # Replaces switchport_nonegotiate value 'Off' with true and 'On' with false
+  def self.switchport_nonegotiate_from_output(output)
+    output_switchport = output[:switchport_nonegotiate]
+    if output_switchport
+      output[:switchport_nonegotiate] = true if output_switchport == 'Off'
+      output[:switchport_nonegotiate] = false if output_switchport == 'On'
+    end
+    output
+  end
+
+  # Returns 'unset' if the given calue is false
+  def self.false_to_unset(false_value)
+    return 'unset' if false_value == false
+    false_value
+  end
+
+  # If given an array, converts it to a string
+  def self.array_to_string(array_value)
+    return array_value unless array_value.class == Array
+    _string_value = "#{array_value[0]} #{array_value[1]}"
+  end
+
+  def commands_hash
+    Puppet::Provider::IosNetworkTrunk::CiscoIos.commands_hash
+  end
+
+  def get(context, _names = nil)
+    name_output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_interface_names(commands_hash))
+    interface_names = Puppet::Provider::NetworkTrunk::CiscoIos.interface_names_from_cli(name_output)
+
+    return_instances = []
+    [*interface_names].each do |interface_name|
+      get_value_cmd = PuppetX::CiscoIOS::Utility.get_values(commands_hash).to_s.gsub(%r{<name>}, interface_name)
+      output = context.transport.run_command_enable_mode(get_value_cmd)
+      # If this interface is not a switchable port ignore
+      if !output.nil? && (!output.include? ' is not a switchable port')
+        return_instance = Puppet::Provider::IosNetworkTrunk::CiscoIos.instance_from_cli(output, interface_name)
+        return_instances << Puppet::Provider::IosNetworkTrunk::CiscoIos.switchport_nonegotiate_from_output(return_instance)
+      end
+    end
+    PuppetX::CiscoIOS::Utility.enforce_simple_types(context, return_instances)
+  end
+
+  def set(context, changes)
+    changes.each do |name, change|
+      should = change[:should]
+      context.updating(name) do
+        update(context, name, should)
+      end
+    end
+  end
+
+  def update(context, _name, should)
+    array_of_commands_to_run = Puppet::Provider::IosNetworkTrunk::CiscoIos.commands_from_instance(should)
+    array_of_commands_to_run.each do |command|
+      context.transport.run_command_conf_t_mode(command)
+    end
+  end
+
+  def create(context, name, should)
+    commands = Puppet::Provider::IosNetworkTrunk::CiscoIos.commands_from_instance(should).join("\n")
+    context.transport.run_command_interface_mode(name, commands)
+  end
+
+  alias update create
+
+  def delete(context, name)
+    delete_hash = { name: name, ensure: 'absent' }
+    context.transport.run_command_interface_mode(name, Puppet::Provider::IosNetworkTrunk::CiscoIos.commands_from_instance(delete_hash).join("\n"))
+  end
+
+  def canonicalize(_context, resources)
+    resources
+  end
+end

--- a/lib/puppet/provider/ios_network_trunk/command.yaml
+++ b/lib/puppet/provider/ios_network_trunk/command.yaml
@@ -1,0 +1,26 @@
+---
+attributes:
+  access_vlan:
+    default:
+      get_value: '.*(?:(?:Access Mode VLAN: )(?:(?<access_vlan>.*) .*\\n)).*'
+      set_value: 'switchport access vlan <access_vlan>' # <1-4094>
+      unset_value: 'no switchport access vlan' # <cr>
+      can_have_no_match: 'true'
+  voice_vlan: # Only supported on access VLANs, https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst2960/software/release/12-2_40_se/configuration/guide/scg/swvoip.pdf
+    default:
+      get_value: '.*(?:(?:Voice VLAN: )(?:(?<voice_vlan>.*) .*\\n)).*'
+      set_value: 'switchport voice vlan <voice_vlan>' # <1-4094, dot1p, none, untagged>
+      unset_value: 'no switchport voice vlan' # <cr>
+      can_have_no_match: 'true'
+  switchport_nonegotiate:
+    default:
+      get_value: '(?:Negotiation of Trunking: (Off|On))'
+      set_value: 'switchport nonegotiate' # <cr>
+      unset_value: 'no switchport nonegotiate' # <cr>
+      can_have_no_match: 'true'
+  allowed_vlans:
+    default:
+      get_value: '(?:Trunking VLANs Enabled: (.*)$)'
+      set_value: 'switchport trunk allowed vlan <allowed_vlans>' # <WORD, add WORD, all, except WORD, none, remove WORD>
+      unset_value: 'no switchport trunk allowed vlan' # <cr>
+      can_have_no_match: 'true'

--- a/lib/puppet/provider/network_interface/cisco_ios.rb
+++ b/lib/puppet/provider/network_interface/cisco_ios.rb
@@ -62,7 +62,7 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         instance_data = []
         data.each do |interface|
           instance_data << {
-            name: shorthand_to_full(interface['Port']),
+            name: PuppetX::CiscoIOS::Utility.shorthand_to_full(interface['Port']),
             # Convert 10/100/1000 speed values to modelled 10m/100m/1g
             speed: (interface['Speed'][0] == 'a') ? 'auto' : PuppetX::CiscoIOS::Utility.convert_speed_int_to_modelled_value(interface['Speed']),
             duplex: (interface['Duplex'][0] == 'a') ? 'auto' : interface['Duplex'],
@@ -72,22 +72,6 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
         # combine the two arrays
         (instances + instance_data).group_by { |interface| interface[:name] }.map { |_, values| values.inject({}, :merge) }
       end
-    end
-
-    def shorthand_to_full(name)
-      shorthand = name[%r{(^[a-zA-Z]{2})}, 1]
-      port = name[%r{^[a-zA-Z]{2}(.*$)}, 1]
-      full = case shorthand
-             when 'Gi'
-               'GigabitEthernet'
-             when 'Te'
-               'TenGigabitEthernet'
-             when 'Fa'
-               'FastEthernet'
-             when 'Po'
-               'Port-channel'
-             end
-      full + port
     end
 
     def set(context, changes)

--- a/lib/puppet/provider/network_trunk/cisco_ios.rb
+++ b/lib/puppet/provider/network_trunk/cisco_ios.rb
@@ -24,9 +24,9 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
       interface_names
     end
 
-    def self.instance_from_cli(output, interface_name)
+    def self.instance_from_cli(output)
       new_instance = PuppetX::CiscoIOS::Utility.parse_resource(output, commands_hash)
-      new_instance[:name] = interface_name
+      new_instance[:name] = PuppetX::CiscoIOS::Utility.shorthand_to_full(new_instance[:name])
       new_instance[:mode] = PuppetX::CiscoIOS::Utility.convert_network_trunk_mode_cli(new_instance[:mode])
       new_instance.delete_if { |_k, v| v.nil? }
       new_instance[:ensure] = if new_instance[:ensure] || new_instance.size > 1
@@ -64,16 +64,16 @@ unless PuppetX::CiscoIOS::Check.use_old_netdev_type
     end
 
     def get(context, _names = nil)
-      name_output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_interface_names(commands_hash))
-      interface_names = Puppet::Provider::NetworkTrunk::CiscoIos.interface_names_from_cli(name_output)
+      output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
+      # convert the output to an array, breaking at `Name:`
+      output_array = output.split("\n").slice_before(%r{Name:(.*)}).to_a
 
       return_instances = []
-      [*interface_names].each do |interface_name|
-        get_value_cmd = PuppetX::CiscoIOS::Utility.get_values(commands_hash).to_s.gsub(%r{<name>}, interface_name)
-        output = context.transport.run_command_enable_mode(get_value_cmd)
-        # If this interface is not a switchable port ignore
-        if !output.nil? && (!output.include? ' is not a switchable port')
-          return_instances << Puppet::Provider::NetworkTrunk::CiscoIos.instance_from_cli(output, interface_name)
+      # drop the first item in the array which is the command...
+      output_array.drop(1).each do |interface|
+        interface_output = interface.join("\n")
+        unless interface_output.include? ' is not a switchable port'
+          return_instances << Puppet::Provider::NetworkTrunk::CiscoIos.instance_from_cli(interface_output)
         end
       end
       PuppetX::CiscoIOS::Utility.enforce_simple_types(context, return_instances)

--- a/lib/puppet/provider/network_trunk/command.yaml
+++ b/lib/puppet/provider/network_trunk/command.yaml
@@ -1,6 +1,6 @@
 ---
 get_values:
-  default: 'show interfaces <name> switchport'
+  default: 'show interfaces switchport'
 get_interfaces_command:
   default: 'show running-config | include ^interface'
 get_interfaces_get_value:
@@ -19,7 +19,7 @@ attributes:
     - device: '2960'
   name:
     default:
-      get_value: '^.*interface (?<name>\S*)\n'
+      get_value: '^.*Name: (?<name>\S*)\n'
       can_have_no_match: 'true'
   encapsulation:
     default:

--- a/lib/puppet/transport/cisco_ios.rb
+++ b/lib/puppet/transport/cisco_ios.rb
@@ -261,6 +261,7 @@ module Puppet::Transport
       elsif mode == ModeState::ENABLED
         send_command(connection, conf_t_cmd)
       end
+
       return_value = send_command(connection, command, true)
       confirm_prompt = Regexp.new(%r{#{commands['default']['new_model_confirm']}})
       # confirm prompt eg.
@@ -282,13 +283,15 @@ module Puppet::Transport
           raise "Could not enter interface mode for interface #{interface_name}"
         end
       end
-      prompt = send_command(connection, command, true)
-      re_conf_confirm = Regexp.new(%r{#{commands['default']['network_trunk_confirm']}})
-      # Network trunk confirm prompt eg.
-      #   Subinterfaces configured on this interface will not be available after switchport.
-      #   Proceed with the command? [confirm]
-      if prompt.match(re_conf_confirm)
-        send_command(connection, '', true)
+      command.split("\n").each do |sub_command|
+        prompt = send_command(connection, sub_command, true)
+        re_conf_confirm = Regexp.new(%r{#{commands['default']['network_trunk_confirm']}})
+        # Network trunk confirm prompt eg.
+        #   Subinterfaces configured on this interface will not be available after switchport.
+        #   Proceed with the command? [confirm]
+        if prompt.match(re_conf_confirm)
+          send_command(connection, '', true)
+        end
       end
       # Exit out of interface mode to save changes
       send_command(connection, 'exit', true)

--- a/lib/puppet/type/ios_network_trunk.rb
+++ b/lib/puppet/type/ios_network_trunk.rb
@@ -1,0 +1,55 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'ios_network_trunk',
+  docs: 'Ethernet logical (switch-port) interface.  Configures VLAN trunking.',
+  features: ['canonicalize', 'simple_get_filter'] + (Puppet::Util::NetworkDevice.current.nil? ? [] : ['remote_resource']),
+  attributes: {
+    ensure: {
+      type:    'Enum[present, absent]',
+      desc:    'Whether the network_trunk should be present or absent on the target system.',
+      default: 'present',
+    },
+    name: {
+      type:   'String',
+      desc:   'The switch interface name, e.g. "Ethernet1"',
+      behaviour: :namevar,
+    },
+    encapsulation: {
+      type:   'Optional[Enum["dot1q","isl","negotiate","none"]]',
+      desc:   'The vlan-tagging encapsulation protocol, usually dot1q',
+    },
+    mode: {
+      type:   'Optional[Enum["access","trunk","dynamic_auto","dynamic_desirable"]]',
+      desc:   'The L2 interface mode, enables or disables trunking',
+    },
+    untagged_vlan: {
+      type:    'Optional[Integer[0, 4095]]',
+      desc:    'VLAN used for untagged VLAN traffic. a.k.a Native VLAN',
+    },
+    tagged_vlans: {
+      type:    'Optional[Array[String]]',
+      desc:    'Array of VLAN names used for tagged packets',
+    },
+    pruned_vlans: {
+      type:    'Optional[Array[String]]',
+      desc:    'Array of VLAN ID numbers used for VLAN pruning',
+    },
+    access_vlan: {
+      type:    'Optional[Variant[Integer[0, 4095], Boolean[false]]]',
+      desc:    'The VLAN to set when the interface is in access mode.',
+    },
+    voice_vlan: {
+      type:    'Optional[Variant[Integer[0, 4095], Enum["dot1p", "none", "untagged"], Boolean[false]]]',
+      desc:    'Sets how voice traffic should be treated by the access port.',
+    },
+    switchport_nonegotiate: {
+      type:    'Optional[Boolean]',
+      desc:    'When set, prevents the port from sending DTP (Dynamic Trunk Port) messages. Set automatically to true while in `access mode` and cannot be set in `dynamic_*` mode.',
+    },
+    allowed_vlans: {
+      type:    'Optional[Variant[Enum["all", "none"], Tuple[Enum["add", "remove", "except"], String], String, Boolean[false]]]',
+      desc:    'Sets which VLANs the access port will use when trunking is enabled.',
+    },
+  },
+)

--- a/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
+++ b/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
@@ -547,5 +547,21 @@ module PuppetX::CiscoIOS
       end
       return_value
     end
+
+    def self.shorthand_to_full(name)
+      shorthand = name[%r{(^[a-zA-Z]{2})}, 1]
+      port = name[%r{^[a-zA-Z]{2}(.*$)}, 1]
+      full = case shorthand
+             when 'Gi'
+               'GigabitEthernet'
+             when 'Te'
+               'TenGigabitEthernet'
+             when 'Fa'
+               'FastEthernet'
+             when 'Po'
+               'Port-channel'
+             end
+      full + port
+    end
   end
 end

--- a/spec/acceptance/ios_network_trunk_spec.rb
+++ b/spec/acceptance/ios_network_trunk_spec.rb
@@ -1,19 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'ios_network_trunk' do
-  before(:all) do
-    # Remove if already present
-    # NOTE That this will fail on a 2960
-    # as switchport is always on
-    pp = <<-EOS
-    ios_network_trunk { 'Port-channel1':
-      ensure => 'absent',
-    }
-    EOS
-    make_site_pp(pp)
-    run_device(allow_changes: true)
-  end
-
   it 'add a network trunk' do
     pp = <<-EOS
     ios_network_trunk { 'Port-channel1':

--- a/spec/acceptance/ios_network_trunk_spec.rb
+++ b/spec/acceptance/ios_network_trunk_spec.rb
@@ -40,7 +40,7 @@ describe 'ios_network_trunk' do
       mode => 'trunk',
       untagged_vlan => 42,
       access_vlan => 8,
-      switchport_nonegotiate => true,
+      switchport_nonegotiate => false,
       allowed_vlans => ['except', '500-600']
     }
     EOS
@@ -58,7 +58,7 @@ describe 'ios_network_trunk' do
     expect(result).to match(%r{untagged_vlan => 42})
     expect(result).to match(%r{access_vlan => 8})
     expect(result).to match(%r{ensure => 'present'})
-    expect(result).to match(%r{switchport_nonegotiate => true})
+    expect(result).to match(%r{switchport_nonegotiate => false})
     expect(result).to match(%r{allowed_vlans => '1-499,601-4094'})
   end
 

--- a/spec/acceptance/ios_network_trunk_spec.rb
+++ b/spec/acceptance/ios_network_trunk_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper_acceptance'
+
+describe 'ios_network_trunk' do
+  before(:all) do
+    # Remove if already present
+    # NOTE That this will fail on a 2960
+    # as switchport is always on
+    pp = <<-EOS
+    ios_network_trunk { 'Port-channel1':
+      ensure => 'absent',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+  end
+
+  it 'add a network trunk' do
+    pp = <<-EOS
+    ios_network_trunk { 'Port-channel1':
+      ensure => 'present',
+      mode => 'access',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_network_trunk', 'Port-channel1')
+    expect(result).to match(%r{Port-channel1.*})
+    expect(result).to match(%r{mode.*access})
+    expect(result).to match(%r{ensure.*present})
+  end
+
+  it 'edit an existing trunk' do
+    pp = <<-EOS
+    ios_network_trunk { 'Port-channel1':
+      ensure => 'present',
+      encapsulation => 'dot1q',
+      mode => 'trunk',
+      untagged_vlan => 42,
+      access_vlan => 8,
+      switchport_nonegotiate => true,
+      allowed_vlans => ['except', '500-600']
+    }
+    EOS
+
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_network_trunk', 'Port-channel1')
+    expect(result).to match(%r{'Port-channel1'})
+    # Not set/read on a 2960
+    expect(result).to match(%r{encapsulation => 'dot1q'}) if result =~ %r{encapsulation =>}
+    expect(result).to match(%r{mode => 'trunk'})
+    expect(result).to match(%r{untagged_vlan => 42})
+    expect(result).to match(%r{access_vlan => 8})
+    expect(result).to match(%r{ensure => 'present'})
+    expect(result).to match(%r{switchport_nonegotiate => true})
+    expect(result).to match(%r{allowed_vlans => '1-499,601-4094'})
+  end
+
+  it 'remove an existing interface' do
+    # NOTE That this will fail on a 2960
+    # as switchport is always on
+    pp = <<-EOS
+    ios_network_trunk { 'Port-channel1':
+      ensure => 'absent',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_network_trunk', 'Port-channel1')
+    expect(result).to match(%r{Port-channel1.*})
+    # Cannot currently test
+    # expect(result).to match(%r{ensure.*absent})
+  end
+end

--- a/spec/unit/puppet/provider/ios_network_trunk/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_network_trunk/cisco_ios_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module Puppet::Provider::IosNetworkTrunk; end
+require 'puppet/provider/ios_network_trunk/cisco_ios'
+
+RSpec.describe Puppet::Provider::IosNetworkTrunk::CiscoIos do
+  def self.load_test_data
+    PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/test_data.yaml', false)
+  end
+
+  context 'Read tests:' do
+    load_test_data['default']['read_tests'].each do |test_name, test|
+      it test_name.to_s do
+        fake_device(test['device'])
+        type_name = described_class.instance_method(:get).source_location.first.match(%r{provider\/(.*)\/})[1]
+        new_type = Puppet::Type.type(type_name)
+        dummy_context = Puppet::ResourceApi::PuppetContext
+        dummy_context = dummy_context.new(new_type.type_definition.definition)
+        return_non_enforced = [described_class.instance_from_cli(test['cli'], test['expectations'].first[:name])]
+        return_enforced = PuppetX::CiscoIOS::Utility.enforce_simple_types(dummy_context, return_non_enforced)
+        expect(return_enforced).to eq test['expectations']
+      end
+    end
+  end
+  it_behaves_like 'commands created from instance'
+
+  it_behaves_like 'a noop canonicalizer'
+end

--- a/spec/unit/puppet/provider/ios_network_trunk/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_network_trunk/cisco_ios_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Puppet::Provider::IosNetworkTrunk::CiscoIos do
         new_type = Puppet::Type.type(type_name)
         dummy_context = Puppet::ResourceApi::PuppetContext
         dummy_context = dummy_context.new(new_type.type_definition.definition)
-        return_non_enforced = [described_class.instance_from_cli(test['cli'], test['expectations'].first[:name])]
+        return_non_enforced = [described_class.instance_from_cli(test['cli'])]
         return_enforced = PuppetX::CiscoIOS::Utility.enforce_simple_types(dummy_context, return_non_enforced)
         expect(return_enforced).to eq test['expectations']
       end

--- a/spec/unit/puppet/provider/ios_network_trunk/test_data.yaml
+++ b/spec/unit/puppet/provider/ios_network_trunk/test_data.yaml
@@ -2,7 +2,7 @@
 default:
   read_tests:
     "interface no switchport trunk":
-      cli: "show interfaces GigabitEthernet3/44 switchport\nName: Gi3/44\nSwitchport: Disabled\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/44\nSwitchport: Disabled\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/44'
         :ensure: 'absent'

--- a/spec/unit/puppet/provider/ios_network_trunk/test_data.yaml
+++ b/spec/unit/puppet/provider/ios_network_trunk/test_data.yaml
@@ -1,0 +1,89 @@
+---
+default:
+  read_tests:
+    "interface no switchport trunk":
+      cli: "show interfaces GigabitEthernet3/44 switchport\nName: Gi3/44\nSwitchport: Disabled\n\ncisco-c6503e#"
+      expectations:
+      - :name: 'GigabitEthernet3/44'
+        :ensure: 'absent'
+  update_tests:
+    "trunk access_vlan":
+      commands:
+      - 'switchport'
+      - 'switchport access vlan 6'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :access_vlan: 6
+    "trunk access_vlan unset":
+      commands:
+      - 'switchport'
+      - 'no switchport access vlan'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :access_vlan: false
+    "trunk voice_vlan":
+      commands:
+      - 'switchport'
+      - 'switchport voice vlan 7'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :voice_vlan: 7
+    "trunk voice_vlan unset":
+      commands:
+      - 'switchport'
+      - 'no switchport voice vlan'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :voice_vlan: false
+    "trunk allowed_vlans":
+      commands:
+      - 'switchport'
+      - 'switchport trunk allowed vlan 1-5'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :allowed_vlans: '1-5'
+    "trunk allowed_vlans all":
+      commands:
+      - 'switchport'
+      - 'switchport trunk allowed vlan all'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :allowed_vlans: 'all'
+    "trunk allowed_vlans except":
+      commands:
+      - 'switchport'
+      - 'switchport trunk allowed vlan except 1-4093'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :allowed_vlans: 'except 1-4093'
+    "trunk allowed_vlans unset":
+      commands:
+      - 'switchport'
+      - 'no switchport trunk allowed vlan'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :allowed_vlans: false
+    "trunk switchport_nonegotiate":
+      commands:
+      - 'switchport'
+      - 'switchport nonegotiate'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :switchport_nonegotiate: true
+    "trunk switchport_nonegotiate unset":
+      commands:
+      - 'switchport'
+      - 'no switchport nonegotiate'
+      instance:
+       :name: 'GigabitEthernet3/42'
+       :ensure: 'present'
+       :switchport_nonegotiate: false

--- a/spec/unit/puppet/provider/network_trunk/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/network_trunk/cisco_ios_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Puppet::Provider::NetworkTrunk::CiscoIos do
         new_type = Puppet::Type.type(type_name)
         dummy_context = Puppet::ResourceApi::PuppetContext
         dummy_context = dummy_context.new(new_type.type_definition.definition)
-        return_non_enforced = [described_class.instance_from_cli(test['cli'], test['expectations'].first[:name])]
+        return_non_enforced = [described_class.instance_from_cli(test['cli'])]
         return_enforced = PuppetX::CiscoIOS::Utility.enforce_simple_types(dummy_context, return_non_enforced)
         expect(return_enforced).to eq test['expectations']
       end

--- a/spec/unit/puppet/provider/network_trunk/test_data.yaml
+++ b/spec/unit/puppet/provider/network_trunk/test_data.yaml
@@ -2,66 +2,66 @@
 default:
   read_tests:
     "interface no switchport trunk":
-      cli: "show interfaces GigabitEthernet3/44 switchport\nName: Gi3/44\nSwitchport: Disabled\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/44\nSwitchport: Disabled\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/44'
         :ensure: 'absent'
     "trunk encapsulation dot1q":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Trunking Encapsulation: dot1q\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Trunking Encapsulation: dot1q\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :encapsulation: 'dot1q'
     "trunk encapsulation isl":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Trunking Encapsulation: isl\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Trunking Encapsulation: isl\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :encapsulation: 'isl'
     "trunk encapsulation negotiate":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Trunking Encapsulation: negotiate\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Trunking Encapsulation: negotiate\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :encapsulation: 'negotiate'
     "trunk encapsulation none":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Trunking Encapsulation: none\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Trunking Encapsulation: none\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :encapsulation: 'none'
     "trunk mode access":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: static access\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: static access\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :mode: 'access'
     "trunk mode trunk":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: trunk\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: trunk\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :mode: 'trunk'
     "trunk mode dynamic_desirable":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: dynamic desirable\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: dynamic desirable\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :mode: 'dynamic_desirable'
     "trunk mode dynamic_auto":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: dynamic auto\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: dynamic auto\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :mode: 'dynamic_auto'
     "trunk untagged_vlan":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nTrunking Native Mode VLAN: 1 (default)\n\ncisco-c6503e#"
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nTrunking Native Mode VLAN: 1 (default)\n\ncisco-c6503e#"
       expectations:
       - :name: 'GigabitEthernet3/42'
         :ensure: 'present'
         :untagged_vlan: 1
     "trunk encapculation mode untagged_vlan tagged_vlans pruned_vlans":
-      cli: "show interfaces GigabitEthernet3/42 switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: dynamic desirable\n
+      cli: "show interfaces switchport\nName: Gi3/42\nSwitchport: Enabled\nAdministrative Mode: dynamic desirable\n
            Operational Mode: down\nAdministrative Trunking Encapsulation: dot1q\nNegotiation of Trunking: On\nAccess Mode VLAN: 1 (default)\n
            Trunking Native Mode VLAN: 1 (default)\nAdministrative Native VLAN tagging: enabled\nOperational Native VLAN tagging: disabled\n
            Voice VLAN: none\nAdministrative private-vlan host-association: none \nAdministrative private-vlan mapping: none \n

--- a/spec/unit/puppet/type/ios_network_trunk_spec.rb
+++ b/spec/unit/puppet/type/ios_network_trunk_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+describe 'the ios_network_trunk type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:ios_network_trunk)).not_to be_nil
+  end
+end


### PR DESCRIPTION
Additional attributes added:
- 'access_vlan', the VLAN which will be used when in access mode.
- 'voice_vlan', configures how IP voice traffic is to be handled.
- 'switchport_nonegotiate', prevents the sending of dynamic trunk port messages when set.
- 'allowed_vlans', designates which VLANs can be used when trunking.
