### PR TITLE
(maint) Improve readability of error messages returned from the device

### DIFF
--- a/lib/puppet/transport/cisco_ios.rb
+++ b/lib/puppet/transport/cisco_ios.rb
@@ -144,7 +144,8 @@ module Puppet::Transport
                       else
                         options
                       end
-        raise "'#{return_value}' Error sending '#{sent_string}'"
+
+        raise "\n'#{return_value}'\nError sending: '#{sent_string}'"
       end
       if debug
         caller.each do |line|


### PR DESCRIPTION
Example. From:

```
Error: ios_radius_global[default]: Updating: Failed after 1.92 seconds: 'radius-server attribute 25 access-request include
                                                  ^
% Invalid input detected at '^' marker.

cisco-4507r(config)#' Error sending 'radius-server attribute 25 access-request include'
```

To:

```
Error: ios_radius_global[default]: Updating: Failed after 0.738676 seconds: 
'radius-server attribute 25 access-request include
                                                  ^
% Invalid input detected at '^' marker.

cisco-4507r(config)#'
Error sending: 'radius-server attribute 25 access-request include'
```