### PR TITLE
(FM-7764) - IOS Additional Syslog Settings created

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ To save the running config, it is possible to use the `cisco_ios::config_save` t
 bolt task run cisco_ios::config_save --nodes ios --modulepath <module_installation_dir> --inventoryfile <inventory_yaml_path>
 ```
 
-The following [inventory file](https://puppet.com/docs/bolt/latest/inventory_file.html) can be used to connect to your swicth.
+The following [inventory file](https://puppet.com/docs/bolt/latest/inventory_file.html) can be used to connect to your switch.
+
 ```yaml
 # inventory.yaml
 nodes:
@@ -209,10 +210,12 @@ The `--modulepath` param can be retrieved by typing `puppet config print modulep
 Please see the netdev_stdlib docs https://github.com/puppetlabs/netdev_stdlib/blob/master/README.md
 
 ### Classes
+
 * [`cisco_ios`](#cisco_ios):
 * [`cisco_ios::install`](#cisco_iosinstall): Private class
 
 ### Resource types
+
 * [`ios_aaa_accounting`](#ios_aaa_accounting): Configure aaa accounting on device
 * [`ios_aaa_authentication`](#ios_aaa_authentication): Configure aaa authentication on device
 * [`ios_aaa_authorization`](#ios_aaa_authorization): Configure aaa authorization on device
@@ -223,6 +226,7 @@ Please see the netdev_stdlib docs https://github.com/puppetlabs/netdev_stdlib/bl
 * [`ios_network_trunk`](#ios_network_trunk): Ethernet logical (switch-port) interface. Configures VLAN trunking.
 * [`ios_stp_global`](#ios_stp_global): Manages the Cisco Spanning-tree Global configuration resource.
 * [`ios_network_dns`](#ios_network_dns): Configure DNS settings for network devices.
+* [`ios_additional_syslog_settings`](#ios_additional_syslog_settings): Configure additional global syslog settings.
 
 #### cisco_ios
 
@@ -943,10 +947,12 @@ Data type: `Optional[Variant[Integer[0, 4095], Boolean[false]]`
 The VLAN to set when the interface is in access mode. Setting it to false will revert it to the default value.
 
 Examples:
-```
+
+```Puppet
 access_vlan => 405
 ```
-```
+
+```Puppet
 access_vlan => false
 ```
 
@@ -957,10 +963,12 @@ Data type: `Optional[Variant[Integer[0, 4095], Enum["dot1p", "none", "untagged"]
 Sets how voice traffic should be treated by the access port. Setting it to false will revert it to the default value.
 
 Examples:
-```
+
+```Puppet
 access_vlan => 221
 ```
-```
+
+```Puppet
 access_vlan => 'dot1p'
 ```
 
@@ -971,13 +979,16 @@ Data type: `Optional[Variant[Enum["all", "none"], Tuple[Enum["add", "remove", "e
 Sets which VLANs the access port will use when trunking is enabled. Setting it to false will revert it to the default value.
 
 Examples:
-```
+
+```Puppet
 access_vlan => '101-202'
 ```
-```
+
+```Puppet
 access_vlan => 'none'
 ```
-```
+
+```Puppet
 access_vlan => ['except', '204-301']
 ```
 
@@ -988,7 +999,8 @@ Data type: `Optional[Boolean]`
 When set, prevents the port from sending DTP (Dynamic Trunk Port) messages. Set automatically to true while in 'access mode' and cannot be set in 'dynamic_*' mode.
 
 Examples:
-```
+
+```Puppet
 access_vlan => true
 ```
 
@@ -1157,6 +1169,60 @@ Data type: `Optional[Boolean]`
 Sets whether the Domain Name Server (DNS) lookup feature should be enabled.
 
 See `network_dns` for other available fields.
+
+### ios_additional_syslog_settings
+
+Configure additional global syslog settings.
+
+#### Properties
+
+The following properties are available in the `ios_additional_syslog_settings` type.
+
+##### `trap`
+
+Data type: `Optional[Variant[Integer[0,7], Enum["unset"]]]`
+
+Set the syslog server logging level, can be set to a severity level of [0-7] or 'unset'.
+
+Examples:
+
+```Puppet
+ios_additional_syslog_settings { "default":
+  trap => 3,
+}
+```
+
+```Puppet
+ios_additional_syslog_settings { "default":
+  trap => 'unset',
+}
+```
+
+##### `origin_id`
+
+Data type: `Optional[Variant[Enum['hostname', 'ip', 'ipv6', unset], Tuple[Enum['string'], String]]]`
+
+Sets an origin-id to be added to all syslog messages, can be set to a default value taken from the switch itself or a designated one word string.
+
+Examples:
+
+```Puppet
+ios_additional_syslog_settings { "default":
+  origin_id => 'ipv6',
+}
+```
+
+```Puppet
+ios_additional_syslog_settings { "default":
+  origin_id => ['string', 'Main'],
+}
+```
+
+```Puppet
+ios_additional_syslog_settings { "default":
+  origin_id => 'unset',
+}
+```
 
 ## Limitations
 

--- a/lib/puppet/provider/ios_additional_syslog_settings/cisco_ios.rb
+++ b/lib/puppet/provider/ios_additional_syslog_settings/cisco_ios.rb
@@ -1,0 +1,89 @@
+require_relative '../../util/network_device/cisco_ios/device'
+require_relative '../../../puppet_x/puppetlabs/cisco_ios/utility'
+
+# Register legacy Puppet provider instance for compatibility with other netdev_stdlib providers
+# Please do not do this with other Resource API based providers
+Puppet::Type.type(:syslog_settings).provide(:ios) do
+end
+
+# Utility functions to parse out the Interface
+class Puppet::Provider::IosAdditionalSyslogSettings::CiscoIos
+  def self.commands_hash
+    @commands_hash ||= PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/command.yaml')
+  end
+
+  def self.instances_from_cli(output)
+    new_instance_fields = []
+    new_instance = PuppetX::CiscoIOS::Utility.parse_resource(output, commands_hash)
+
+    new_instance[:name] = 'default'
+    new_instance.delete_if { |_k, v| v.nil? }
+
+    # convert cli values to puppet values
+    new_instance[:trap] = PuppetX::CiscoIOS::Utility.convert_level_name_to_int(new_instance[:trap]) if new_instance[:trap]
+    new_instance[:origin_id] = Puppet::Provider::IosAdditionalSyslogSettings::CiscoIos.origin_id_extract(new_instance[:origin_id]) if new_instance[:origin_id]
+
+    new_instance_fields << new_instance
+    new_instance_fields
+  end
+
+  def self.commands_from_is_should(is, should)
+    attributes_that_differ = (should.to_a - is.to_a).to_h
+    array_of_commands = PuppetX::CiscoIOS::Utility.build_commmands_from_attribute_set_values(attributes_that_differ, commands_hash)
+    array_of_commands
+  end
+
+  def self.origin_id_command(instance)
+    if instance[:origin_id].class == Array
+      instance[:origin_id] = "#{instance[:origin_id][0]} #{instance[:origin_id][1]}"
+    end
+    instance
+  end
+
+  def self.origin_id_extract(id)
+    if id =~ %r{ }
+      split_id = id.split(' ')
+      id = Array[split_id[0], split_id[1]]
+    end
+    id
+  end
+
+  def commands_hash
+    Puppet::Provider::IosAdditionalSyslogSettings::CiscoIos.commands_hash
+  end
+
+  def get(context, _names = nil)
+    output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
+    return [] if output.nil?
+    return_value = Puppet::Provider::IosAdditionalSyslogSettings::CiscoIos.instances_from_cli(output)
+    PuppetX::CiscoIOS::Utility.enforce_simple_types(context, return_value)
+  end
+
+  def set(context, changes)
+    changes.each do |name, change|
+      is = change.key?(:is) ? change[:is] : (get(context) || []).find { |key| key[:name] == name }
+      should = change[:should]
+
+      context.updating(name) do
+        update(context, name, is, should)
+      end
+    end
+  end
+
+  def update(context, _name, is, should)
+    should_cleaned = Puppet::Provider::IosAdditionalSyslogSettings::CiscoIos.origin_id_command(should)
+
+    array_of_commands_to_run = Puppet::Provider::IosAdditionalSyslogSettings::CiscoIos.commands_from_is_should(is, should_cleaned)
+    array_of_commands_to_run.each do |command|
+      context.transport.run_command_conf_t_mode(command)
+    end
+  end
+
+  def create(context, _name, _should); end
+
+  def delete(context, _name); end
+
+  def canonicalize(_context, resources)
+    resources
+  end
+end

--- a/lib/puppet/provider/ios_additional_syslog_settings/command.yaml
+++ b/lib/puppet/provider/ios_additional_syslog_settings/command.yaml
@@ -1,0 +1,16 @@
+---
+get_values:
+  default: 'show running-config | include logging'
+attributes:
+  trap:
+    default:
+      get_value: '^logging trap (?<monitor>debugging|informational|notifications|warnings|errors|critical|alerts|emergencies)$'
+      set_value: 'logging trap <trap>'
+      unset_value: 'no logging trap'
+      can_have_no_match: 'true'
+  origin_id:
+    default:
+      get_value: '^logging origin-id (?<origin_id>hostname|ip|ipv6|string\s\S*)$'
+      set_value: 'logging origin-id <origin_id>'
+      unset_value: 'no logging origin-id'
+      can_have_no_match: 'true'

--- a/lib/puppet/type/ios_additional_syslog_settings.rb
+++ b/lib/puppet/type/ios_additional_syslog_settings.rb
@@ -1,0 +1,23 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'ios_additional_syslog_settings',
+  docs: 'Configure global syslog settings',
+  features: ['remote_resource'],
+  attributes: {
+    name:         {
+      type:      'String',
+      desc:      'Name, generally "default", not used to manage the resource',
+      behaviour: :namevar,
+      default:   'default',
+    },
+    trap:    {
+      type:    'Optional[Variant[Integer[0,7], Enum["unset"]]]', # <0-7, 'unset'>
+      desc:    "Set the syslog server logging level, severity level [0-7] or 'unset'",
+    },
+    origin_id:    {
+      type:    "Optional[Variant[Enum['hostname', 'ip', 'ipv6', unset], Tuple[Enum['string'], String]]]", # <'hostname', 'ip', 'ipv6', 'string WORD', 'unset'
+      desc:    'Sets an origin-id to be added to all syslog messages.',
+    },
+  },
+)

--- a/spec/acceptance/ios_additional_syslog_settings_spec.rb
+++ b/spec/acceptance/ios_additional_syslog_settings_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper_acceptance'
+
+describe 'ios_additional_syslog_settings' do
+  before(:all) do
+    # set to known values
+    pp = <<-EOS
+    ios_additional_syslog_settings { 'default':
+      trap => 'unset',
+      origin_id => 'unset',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+  end
+
+  it 'edit ios_additional_syslog_settings' do
+    pp = <<-EOS
+    ios_additional_syslog_settings { 'default':
+      trap => 3,
+      origin_id => 'ipv6',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_additional_syslog_settings', 'default')
+    expect(result).to match(%r{trap => 3})
+    expect(result).to match(%r{origin_id => 'ipv6'})
+  end
+
+  it 'edit ios_additional_syslog_settings again' do
+    pp = <<-EOS
+    ios_additional_syslog_settings { 'default':
+      trap => 5,
+      origin_id => ['string', 'thecakeisalie'],
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_additional_syslog_settings', 'default')
+    expect(result).to match(%r{trap => 5})
+    expect(result).to match(%r{origin_id => \['string', 'thecakeisalie'\]})
+  end
+
+  it 'set back to normal' do
+    # set to known values
+    pp = <<-EOS
+    ios_additional_syslog_settings { 'default':
+      trap => 'unset',
+      origin_id => 'unset',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    result = run_resource('ios_additional_syslog_settings', 'default')
+    expect(result).not_to match(%r{trap =>})
+    expect(result).not_to match(%r{origin_id =>})
+  end
+end

--- a/spec/unit/puppet/provider/ios_additional_syslog_settings/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_additional_syslog_settings/cisco_ios_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+module Puppet::Provider::IosAdditionalSyslogSettings; end
+require 'puppet/provider/ios_additional_syslog_settings/cisco_ios'
+
+RSpec.describe Puppet::Provider::IosAdditionalSyslogSettings::CiscoIos do
+  let(:utility) { described_class }
+
+  def self.load_test_data
+    PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/test_data.yaml', false)
+  end
+
+  it_behaves_like 'resources parsed from cli'
+
+  context 'Update tests:' do
+    load_test_data['default']['update_tests'].each do |test_name, test|
+      it test_name.to_s do
+        expect(described_class.commands_from_is_should(test['is'], test['should'])).to eq test['cli']
+      end
+    end
+  end
+
+  it_behaves_like 'a noop canonicalizer'
+
+  describe 'origin_id_command' do
+    it 'given array' do
+      result = utility.origin_id_command(Hash[:origin_id, ['string', 'thecakeisalie']])
+      expect(result[:origin_id]).to eq 'string thecakeisalie'
+    end
+    it 'given string' do
+      result = utility.origin_id_command(Hash[:origin_id, 'ipv6'])
+      expect(result[:origin_id]).to eq 'ipv6'
+    end
+  end
+
+  describe 'origin_id_extract' do
+    it 'given array' do
+      result = utility.origin_id_extract('string thecakeisalie')
+      expect(result).to eq ['string', 'thecakeisalie']
+    end
+    it 'given string' do
+      result = utility.origin_id_extract('ipv6')
+      expect(result).to eq 'ipv6'
+    end
+  end
+end

--- a/spec/unit/puppet/provider/ios_additional_syslog_settings/test_data.yaml
+++ b/spec/unit/puppet/provider/ios_additional_syslog_settings/test_data.yaml
@@ -1,0 +1,27 @@
+---
+default:
+  read_tests:
+    "raw output from 2690":
+      cli: "show running-config all | section logging\nno service pt-vty-logging\nno logging on\nno ip sla logging traps\nlogging system disk sup-bootdisk:\nlogging system console disk sup-bootdisk:\nlogging system console\nlogging system\nlogging trap informational\nlogging delimiter tcp\nno logging origin-id\nlogging facility local7\nlogging source-interface Loopback42\nlogging 1.1.1.1\nlogging 2.2.2.2\nmonitor traffic-utilization backplane  logging interval 300\nmonitor traffic-utilization fabric  logging interval 300\ncisco-c6503e#"
+      expectations:
+      - :name: 'default'
+        :trap: 6
+  update_tests:
+    "trap and origin-id changed":
+      cli:
+         - "logging trap 4"
+         - "logging origin-id ipv6"
+      is:
+        :trap: 6
+      should:
+        :trap: 4
+        :origin_id: 'ipv6'
+    "trap and origin-id changed again":
+      cli:
+         - "logging trap 3"
+         - "logging origin-id string thecakeisalie"
+      is:
+        :trap: 6
+      should:
+        :trap: 3
+        :origin_id: 'string thecakeisalie'

--- a/spec/unit/puppet/type/ios_additional_syslog_settings.rb
+++ b/spec/unit/puppet/type/ios_additional_syslog_settings.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+describe 'the ios_additional_syslog_settings type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:ios_additional_syslog_settings)).not_to be_nil
+  end
+end


### PR DESCRIPTION
- Attributes are:
	- `trap`, the syslog server logging level.
	- `origin_id`, an optional id to be added to all syslog messages.