### PR TITLE
(FM-7760) Add ios_snmp_global type and provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,6 +994,89 @@ access_vlan => true
 
 See `network_trunk` for other availible fields.
 
+#### ios_snmp_global
+
+Configures Global snmp settings.
+
+##### Properties
+
+The following properties are available in the `ios_network_trunk` type.
+
+###### `trap_source`
+
+Data type: `Optional[Variant[String, Enum['unset']]]`
+
+Assigns an interface for the source address of all traps. Setting it to 'unset' will revert it to the default value.
+
+Examples:
+```
+trap_source => 'GigabitEthernet0/3'
+```
+```
+trap_source => 'unset'
+```
+
+###### `system_shutdown`
+
+Data type: `Optional[Boolean]`
+
+Enables use of the SNMP reload command.
+
+Examples:
+```
+system_shutdown => true
+```
+
+###### `contact`
+
+Data type: `Optional[Variant[String, Enum['unset']]]`
+
+Sets text for the mib object sysContact. Setting it to 'unset' will revert it to the default value.
+
+Examples:
+```
+contact => 'SNMP_TEST'
+```
+```
+contact => 'unset'
+```
+
+###### `manager`
+
+Data type: `Optional[Boolean]`
+
+When set this value enables the SNMP manager.
+
+Examples:
+```
+manager => true
+```
+
+###### `manager_session_timeout`
+
+Data type: `Optional[Variant[Integer, Enum['unset']]]`
+
+Modifies the SNMP manager timeout parameter.
+
+Examples:
+```
+manager_session_timeout => 20
+```
+```
+manager_session_timeout => unset
+```
+
+###### `ifmib_ifindex_persist`
+
+Data type: `Optional[Boolean]`
+
+Enables IF-MIB ifindex persistence.
+
+Examples:
+```
+ifmib_ifindex_persist => true
+```
+
 ### ios_stp_global
 
 Manages the Cisco Spanning-tree Global configuration resource.

--- a/lib/puppet/provider/ios_snmp_global/cisco_ios.rb
+++ b/lib/puppet/provider/ios_snmp_global/cisco_ios.rb
@@ -1,0 +1,78 @@
+require_relative '../../util/network_device/cisco_ios/device'
+require_relative '../../../puppet_x/puppetlabs/cisco_ios/utility'
+
+# Register legacy Puppet provider instance for compatibility with other netdev_stdlib providers
+# Please do not do this with other Resource API based providers
+Puppet::Type.type(:ios_snmp_global).provide(:ios) do
+end
+
+# Configure the domain name of the device
+class Puppet::Provider::IosSnmpGlobal::CiscoIos
+  def self.commands_hash
+    @commands_hash ||= PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/command.yaml')
+  end
+
+  def self.instances_from_cli(output)
+    new_instance_fields = []
+    new_instance = PuppetX::CiscoIOS::Utility.parse_resource(output, commands_hash)
+    new_instance.delete_if { |_k, v| v.nil? }
+    new_instance[:system_shutdown] = Puppet::Provider::IosSnmpGlobal::CiscoIos.convert_to_boolean(new_instance[:system_shutdown])
+    new_instance[:manager] = Puppet::Provider::IosSnmpGlobal::CiscoIos.convert_to_boolean(new_instance[:manager])
+    new_instance[:ifmib_ifindex_persist] = Puppet::Provider::IosSnmpGlobal::CiscoIos.convert_to_boolean(new_instance[:ifmib_ifindex_persist])
+    new_instance_fields << new_instance
+    new_instance_fields
+  end
+
+  def self.commands_from_instance(instance)
+    commands = []
+    commands += PuppetX::CiscoIOS::Utility.build_commmands_from_attribute_set_values(instance, commands_hash)
+    commands
+  end
+
+  def self.convert_to_boolean(value)
+    if value.nil?
+      false
+    else
+      true
+    end
+  end
+
+  def self.false_to_unset(value)
+    return 'unset' if value == false
+    value
+  end
+
+  def commands_hash
+    Puppet::Provider::IosSnmpGlobal::CiscoIos.commands_hash
+  end
+
+  def get(context, _names = nil)
+    output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
+    return [] if output.nil?
+    return_value = Puppet::Provider::IosSnmpGlobal::CiscoIos.instances_from_cli(output)
+    PuppetX::CiscoIOS::Utility.enforce_simple_types(context, return_value)
+  end
+
+  def set(context, changes)
+    changes.each do |name, change|
+      should = change[:should]
+      context.updating(name) do
+        update(context, name, should)
+      end
+    end
+  end
+
+  def update(context, _name, should)
+    should.each do |key, value|
+      should[key] = Puppet::Provider::IosSnmpGlobal::CiscoIos.false_to_unset(value)
+    end
+    array_of_commands_to_run = Puppet::Provider::IosSnmpGlobal::CiscoIos.commands_from_instance(should)
+    array_of_commands_to_run.each do |command|
+      context.transport.run_command_conf_t_mode(command)
+    end
+  end
+
+  def canonicalize(_context, resources)
+    resources
+  end
+end

--- a/lib/puppet/provider/ios_snmp_global/command.yaml
+++ b/lib/puppet/provider/ios_snmp_global/command.yaml
@@ -1,0 +1,44 @@
+---
+get_values:
+  default: 'show running-config | include snmp'
+attributes:
+  name:
+    default:
+      default: 'default'
+      get_value: 'default'
+  trap_source:
+    default:
+      get_value: '^snmp-server trap-source (?<trap_source>\S*)'
+      set_value: 'snmp-server trap-source <trap_source>'
+      unset_value: 'no snmp-server trap-source'
+      can_have_no_match: 'true'
+  system_shutdown:
+    default:
+      get_value: '^snmp-server system-shutdown'
+      set_value: 'snmp-server system-shutdown'
+      unset_value: 'no snmp-server system-shutdown'
+      can_have_no_match: 'true'
+  contact:
+    default:
+      get_value: '^snmp-server contact (?<contact>\S*)'
+      set_value: 'snmp-server contact <contact>'
+      unset_value: 'no snmp-server contact'
+      can_have_no_match: 'true'
+  manager:
+    default:
+      get_value: '^snmp-server manager$'
+      set_value: 'snmp-server manager'
+      unset_value: 'no snmp-server manager'
+      can_have_no_match: 'true'
+  manager_session_timeout:
+    default:
+      get_value: '^snmp-server manager session-timeout (?<manager_session_timeout>\S*)'
+      set_value: 'snmp-server manager session-timeout <manager_session_timeout>'
+      unset_value: 'no snmp-server manager session-timeout'
+      can_have_no_match: 'true'
+  ifmib_ifindex_persist:
+    default:
+      get_value: '^snmp ifmib ifindex persist'
+      set_value: 'snmp ifmib ifindex persist'
+      unset_value: 'no snmp ifmib ifindex persist'
+      can_have_no_match: 'true'

--- a/lib/puppet/type/ios_snmp_global.rb
+++ b/lib/puppet/type/ios_snmp_global.rb
@@ -1,0 +1,39 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'ios_snmp_global',
+  docs: 'Configures Global snmp settings.',
+  features: ['remote_resource'],
+  attributes: {
+    name:         {
+      type:      'String',
+      desc:      'ID of the snmp global config. Valid values are default.',
+      default:   'default',
+      behaviour: :namevar,
+    },
+    trap_source:  {
+      type:    "Optional[Variant[String, Enum['unset']]]",
+      desc:    'Assigns an interface for the source address of all traps.',
+    },
+    system_shutdown:  {
+      type:    'Optional[Boolean]',
+      desc:    'Enables use of the SNMP reload command.',
+    },
+    contact:  {
+      type:    "Optional[Variant[String, Enum['unset']]]",
+      desc:    'Text for mib object sysContact.',
+    },
+    manager:  {
+      type:    'Optional[Boolean]',
+      desc:    'Enables the SNMP manager.',
+    },
+    manager_session_timeout:  {
+      type:    "Optional[Variant[Integer, Enum['unset']]]",
+      desc:    'Modifies the SNMP manager timeout parameter.',
+    },
+    ifmib_ifindex_persist:  {
+      type:    'Optional[Boolean]',
+      desc:    'Enables IF-MIB ifindex persistence.',
+    },
+  },
+)

--- a/spec/acceptance/ios_snmp_global_spec.rb
+++ b/spec/acceptance/ios_snmp_global_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper_acceptance'
+
+describe 'ios_snmp_global' do
+  it 'set ios_snmp_global' do
+    pp = <<-EOS
+    ios_snmp_global { 'default':
+      trap_source => 'Vlan42',
+      system_shutdown => true,
+      contact => 'SNMP_TEST',
+      manager => true,
+      manager_session_timeout => 20,
+      ifmib_ifindex_persist => true,
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_snmp_global', 'default')
+    expect(result).to match(%r{default.*})
+    expect(result).to match(%r{trap_source => 'Vlan42'})
+    expect(result).to match(%r{system_shutdown => true})
+    expect(result).to match(%r{contact => 'SNMP_TEST'})
+    expect(result).to match(%r{manager => true})
+    expect(result).to match(%r{manager_session_timeout => 20})
+    expect(result).to match(%r{ifmib_ifindex_persist => true})
+  end
+
+  it 'edit ios_snmp_global' do
+    pp = <<-EOS
+    ios_snmp_global { 'default':
+      trap_source => 'Vlan43',
+      system_shutdown => true,
+      contact => 'SNMP_TEST_TWO',
+      manager => true,
+      manager_session_timeout => 'unset',
+      ifmib_ifindex_persist => true,
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_snmp_global', 'default')
+    expect(result).to match(%r{default.*})
+    expect(result).to match(%r{trap_source => 'Vlan43'})
+    expect(result).to match(%r{system_shutdown => true})
+    expect(result).to match(%r{contact => 'SNMP_TEST_TWO'})
+    expect(result).to match(%r{manager => true})
+    expect(result).not_to match(%r{manager_session_timeout =>})
+    expect(result).to match(%r{ifmib_ifindex_persist => true})
+  end
+
+  it 'unset ios_snmp_global' do
+    pp = <<-EOS
+    ios_snmp_global { "default":
+      trap_source => 'unset',
+      system_shutdown => false,
+      contact => 'unset',
+      manager => false,
+      manager_session_timeout => 'unset',
+      ifmib_ifindex_persist => false,
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_snmp_global', 'default')
+    expect(result).to match(%r{default.*})
+    # Default values
+    expect(result).not_to match(%r{trap_source =>})
+    expect(result).to match(%r{system_shutdown => false})
+    expect(result).not_to match(%r{contact =>})
+    expect(result).to match(%r{manager => false})
+    expect(result).not_to match(%r{manager_session_timeout =>})
+    expect(result).to match(%r{ifmib_ifindex_persist => false})
+  end
+end

--- a/spec/unit/puppet/provider/ios_snmp_global/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_snmp_global/cisco_ios_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+module Puppet::Provider::IosSnmpGlobal; end
+require 'puppet/provider/ios_snmp_global/cisco_ios'
+
+RSpec.describe Puppet::Provider::IosSnmpGlobal::CiscoIos do
+  let(:utility) { described_class }
+
+  def self.load_test_data
+    PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/test_data.yaml', false)
+  end
+
+  it_behaves_like 'resources parsed from cli'
+  it_behaves_like 'commands created from instance'
+  it_behaves_like 'a noop canonicalizer'
+
+  describe 'convert_to_boolean' do
+    it 'given value' do
+      input = 'cake'
+      output = true
+      expect(utility.convert_to_boolean(input)).to eq output
+    end
+    it 'given nil' do
+      input = nil
+      output = false
+      expect(utility.convert_to_boolean(input)).to eq output
+    end
+  end
+
+  describe 'false_to_unset' do
+    it 'given string' do
+      input = 'cake'
+      output = 'cake'
+      expect(utility.false_to_unset(input)).to eq output
+    end
+    it 'given true' do
+      input = true
+      output = true
+      expect(utility.false_to_unset(input)).to eq output
+    end
+    it 'given false' do
+      input = false
+      output = 'unset'
+      expect(utility.false_to_unset(input)).to eq output
+    end
+  end
+end

--- a/spec/unit/puppet/provider/ios_snmp_global/test_data.yaml
+++ b/spec/unit/puppet/provider/ios_snmp_global/test_data.yaml
@@ -1,0 +1,57 @@
+---
+default:
+  read_tests:
+    "Start":
+      cli: "show running-config | include snmp\nsnmp-server location Monster Munch caves\nsnmp-server host 9.9.9.9 public udp-port 5555"
+      expectations:
+      - :name: 'default'
+        :system_shutdown: false
+        :manager: false
+        :ifmib_ifindex_persist: false
+  update_tests:
+    "Set":
+      commands:
+      - "snmp-server trap-source GigabitEthernet0/3"
+      - "snmp-server system-shutdown"
+      - "snmp-server contact SNMP_TEST"
+      - "snmp-server manager"
+      - "snmp-server manager session-timeout 20"
+      - "snmp ifmib ifindex persist"
+      instance:
+        :trap_source: 'GigabitEthernet0/3'
+        :system_shutdown: true
+        :contact: 'SNMP_TEST'
+        :manager: true
+        :manager_session_timeout: '20'
+        :ifmib_ifindex_persist: true
+    "Update":
+      commands:
+      - "snmp-server trap-source GigabitEthernet0/4"
+      - "snmp-server system-shutdown"
+      - "snmp-server contact SNMP_TEST_TWO"
+      - "snmp-server manager"
+      - "no snmp-server manager session-timeout"
+      - "snmp ifmib ifindex persist"
+      instance:
+        :trap_source: 'GigabitEthernet0/4'
+        :system_shutdown: true
+        :contact: 'SNMP_TEST_TWO'
+        :manager: true
+        :manager_session_timeout: 'unset'
+        :ifmib_ifindex_persist: true
+    "Unset":
+      commands:
+      - "no snmp-server trap-source"
+      - "no snmp-server system-shutdown"
+      - "no snmp-server contact"
+      - "no snmp-server manager"
+      - "no snmp-server manager session-timeout"
+      - "no snmp ifmib ifindex persist"
+      instance:
+        :trap_source: 'unset'
+        :system_shutdown: 'unset'
+        :contact: 'unset'
+        :manager: 'unset'
+        :manager_session_timeout: 'unset'
+        :ifmib_ifindex_persist: 'unset'
+

--- a/spec/unit/puppet/type/ios_snmp_global_spec.rb
+++ b/spec/unit/puppet/type/ios_snmp_global_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+describe 'the ios_snmp_global type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:ios_snmp_global)).not_to be_nil
+  end
+end


### PR DESCRIPTION
Attributes added:
	- trap_source: assigns an interface for the source address of all traps.
	- system_shutdown: enables use of the SNMP reload command.
	- contact: text for mib object sysContact.
	- manager: enables the SNMP manager.
	- manager_session_timeout: modifies the SNMP manager timeout parameter.
	- ifmib_ifindex_persist: enables IF-MIB ifindex persistence.