### PR TITLE
(FM-7760) add ios_interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Please see the netdev_stdlib docs https://github.com/puppetlabs/netdev_stdlib/bl
 * [`ios_aaa_session_id`](#ios_aaa_session_id): Configure aaa session id on device
 * [`ios_config`](#ios_config): Execute an arbitrary configuration against the cisco_ios device with or without a check for idempotency.
 * [`ios_radius_global`](#ios_radius_global): Extends the radius_global type.
+* [`ios_interface`](#ios_interface): Manage layer 3 configuration on a per Instance basis
 * [`ios_network_trunk`](#ios_network_trunk): Ethernet logical (switch-port) interface. Configures VLAN trunking.
 * [`ios_stp_global`](#ios_stp_global): Manages the Cisco Spanning-tree Global configuration resource.
 * [`ios_network_dns`](#ios_network_dns): Configure DNS settings for network devices.
@@ -933,6 +934,77 @@ An array of [attribute number, attribute options] pairs
 
 
 See `radius_global` for other available fields
+
+### ios_interface
+
+Manage layer 3 configuration on a per Instance basis
+
+#### Properties
+
+The following properties are available in the `ios_interface` type.
+
+##### `mac_notification_added`
+
+Data type: `Optional[Boolean]`
+
+Whether to enable Mac Address added notification for this port.
+
+##### `mac_notification_removed`
+
+Data type: `Optional[Boolean]`
+
+Whether to enable Mac Address removed notification for this port.
+
+##### `link_status_duplicates`
+
+Data type: `Optional[Boolean]`
+
+Whether to permit duplicate SNMP LINKUP and LINKDOWN traps.
+
+##### `logging_event`
+
+Data type: `Optional[Variant[Enum["unset"], Array[Enum["bundle-status","nfas-status","spanning-tree","status","subif-link-status","trunk-status"]]]]`
+
+Whether or not to log certain event messages. If given an array any event logs currently set that are not within the array will be removed.
+
+##### `logging_event_link_status`
+
+Data type: `Optional[Boolean]`
+
+Whether to log UPDOWN and CHANGE event messages.
+
+##### `ip_dhcp_snooping_trust`
+
+Data type: `Optional[Boolean]`
+
+DHCP Snooping trust config
+
+##### `ip_dhcp_snooping_limit`
+
+Data type: `Optional[Variant[Boolean[false], Integer[1, 2048]]]`
+
+DHCP snooping rate limit
+
+##### `flowcontrol_receive`
+
+Data type: `Optional[Enum["desired","on","off"]]`
+
+Flow control (receive) [desired|on|off]
+
+##### Example Usage
+
+```Puppet
+ios_interface { 'GigabitEthernet0/1':
+  mac_notification_added => true,
+  mac_notification_removed => false,
+  link_status => false,
+  logging_event => ['spanning-tree','subif-link-status'],
+  logging_event_link_status => false,
+  ip_dhcp_snooping_trust => true,
+  ip_dhcp_snooping_limit => 1500,
+  flowcontrol_receive => 'desired',
+}
+```
 
 #### ios_network_trunk
 

--- a/TestMatrix.md
+++ b/TestMatrix.md
@@ -30,6 +30,7 @@ The module works against a broad range of IOS and IOS-XE based devices, but we d
 | ios_radius_global               | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | ios_stp_global                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok                   |
 | ios_additional_syslog_settings  | ok                   | ok                   | ok                   | ok                   | ok                   | ok*                  | ok                   |
+| ios_interface                   | ok*                  | ok                   | ok                   | ok*                  | ok*                  | ok                   | ok*                  |
 | name_server                     | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      |
 | network_dns                     | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | network_interface               | ok*                  | ok*                  | ok*                  | ok                   | ok                   | ok                   | ok                   |
@@ -83,6 +84,22 @@ The switch does not support the MTU on a per-interface basis. It does not suppor
 The switch does not support the MTU on a per-interface basis. It does not support the following attributes: [link](https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst3750/software/release/12-2_55_se/configuration/guide/scg3750/swint.html)
 
 * mtu
+
+### ios_interface
+
+#### 2960
+
+#### 4507
+
+#### 6503
+
+The above devices do not support the params `mac_notification_added` or `mac_notification_added`.
+
+#### 4503
+
+#### 6503
+
+The above devices do not support the params `ip_dhcp_snooping_trust` or `ip_dhcp_snooping_limit`.
 
 ### network_trunk
 

--- a/lib/puppet/provider/ios_interface/cisco_ios.rb
+++ b/lib/puppet/provider/ios_interface/cisco_ios.rb
@@ -1,0 +1,121 @@
+require_relative '../../util/network_device/cisco_ios/device'
+require_relative '../../../puppet_x/puppetlabs/cisco_ios/utility'
+
+# IOS Interface Puppet Provider for Cisco IOS devices
+class Puppet::Provider::IosInterface::CiscoIos
+  def self.commands_hash
+    @commands_hash ||= PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/command.yaml')
+  end
+
+  def self.instances_from_cli(output)
+    new_instance_fields = []
+    output.scan(%r{#{PuppetX::CiscoIOS::Utility.get_instances(commands_hash)}}).each do |raw_instance_fields|
+      new_instance = PuppetX::CiscoIOS::Utility.parse_resource(raw_instance_fields, commands_hash)
+      new_instance_fields << PuppetX::CiscoIOS::Utility.device_safe_instance(new_instance, commands_hash)
+    end
+    cleaned_value = []
+    new_instance_fields.each do |instance|
+      instance[:mac_notification_added] = instance[:mac_notification_added].nil? ? false : true
+      instance[:mac_notification_removed] = instance[:mac_notification_removed].nil? ? false : true
+      instance[:link_status_duplicates] = instance[:link_status_duplicates].nil? ? false : true
+      instance[:ip_dhcp_snooping_trust] = instance[:ip_dhcp_snooping_trust].nil? ? false : true
+      instance[:flowcontrol_receive] = 'off' unless instance[:flowcontrol_receive]
+      instance[:ip_dhcp_snooping_limit] = false unless instance[:ip_dhcp_snooping_limit]
+      instance = Puppet::Provider::IosInterface::CiscoIos.clean_logging_event(instance)
+      # Converts 'logging_event_link_status' to a boolean value. The value only appears when
+      #   it is unset as it's set by default, so if it is found it should be set to false.
+      instance[:logging_event_link_status] = (instance[:logging_event_link_status]) ? false : true
+      cleaned_value << instance
+    end
+    cleaned_value
+  end
+
+  def self.commands_from_instance(property_hash, current)
+    commands = []
+    # If unset is supplied in logging_event then if a value is currently set is not in the
+    #   applied manifest, it needs to be removed.
+    if property_hash[:logging_event] == 'unset' && current[:logging_event] && current[:logging_event] != 'unset'
+      current[:logging_event].each do |remove|
+        commands << "no #{PuppetX::CiscoIOS::Utility.build_commmands_from_attribute_set_values({ logging_event: remove }, commands_hash)[0]}"
+      end
+    elsif property_hash[:logging_event] && current[:logging_event] && current[:logging_event] != 'unset'
+      to_remove = []
+      to_remove += current[:logging_event] - property_hash[:logging_event]
+      to_remove.each do |remove|
+        commands << "no #{PuppetX::CiscoIOS::Utility.build_commmands_from_attribute_set_values({ logging_event: remove }, commands_hash)[0]}"
+      end
+    end
+
+    # logging_event requires multiple commands to be built in most cases, as such it is handled
+    #   seperately from the remaining attributes
+    if property_hash[:logging_event] && property_hash[:logging_event].class == Array
+      property_hash[:logging_event].each do |event|
+        commands += PuppetX::CiscoIOS::Utility.build_commmands_from_attribute_set_values({ logging_event: event }, commands_hash)
+      end
+    end
+    property_hash.delete(:logging_event)
+
+    property_hash.each do |key, value|
+      property_hash[key] = Puppet::Provider::IosInterface::CiscoIos.false_to_unset(value)
+    end
+    commands += PuppetX::CiscoIOS::Utility.build_commmands_from_attribute_set_values(property_hash, commands_hash)
+    commands
+  end
+
+  # Returns 'unset' if the given calue is false
+  def self.false_to_unset(false_value)
+    return 'unset' if false_value == false
+    false_value
+  end
+
+  # Clears 'link-status' from 'logging-event'. This is done as it's default nature is
+  #   different than the remaining logging events.
+  def self.clean_logging_event(instance)
+    if instance[:logging_event]
+      if instance[:logging_event].class == Array
+        instance[:logging_event] -= ['link-status']
+      elsif instance[:logging_event].class == String
+        instance.delete(:logging_event) if instance[:logging_event] == 'link-status'
+      end
+    end
+    if instance[:logging_event] && instance[:logging_event].class == String
+      instance[:logging_event] = [instance[:logging_event]]
+    elsif instance[:logging_event].nil?
+      instance[:logging_event] = 'unset'
+    end
+    instance
+  end
+
+  def commands_hash
+    Puppet::Provider::IosInterface::CiscoIos.commands_hash
+  end
+
+  def get(context, _names = nil)
+    output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
+    return [] if output.nil?
+    return_value = Puppet::Provider::IosInterface::CiscoIos.instances_from_cli(output)
+    instances = PuppetX::CiscoIOS::Utility.enforce_simple_types(context, return_value)
+    instances
+  end
+
+  def set(context, changes)
+    changes.each do |name, change|
+      should = change[:should]
+      is = change[:is]
+      context.updating(name) do
+        update(context, name, should, is)
+      end
+    end
+  end
+
+  def update(context, name, should, is)
+    array_of_commands_to_run = Puppet::Provider::IosInterface::CiscoIos.commands_from_instance(should, is)
+    array_of_commands_to_run.each do |command|
+      context.transport.run_command_interface_mode(name, command)
+    end
+  end
+
+  def canonicalize(_context, resources)
+    resources
+  end
+end

--- a/lib/puppet/provider/ios_interface/command.yaml
+++ b/lib/puppet/provider/ios_interface/command.yaml
@@ -1,0 +1,72 @@
+---
+get_values:
+  default: 'show running-config | begin interface'
+get_instances:
+  default: '\\ninterface (?:(?:.| |\\n )*\\n)'
+delete_command_default:
+  default: 'default interface <name>'
+delete_command_no:
+  default: 'no interface <name>'
+attributes:
+  name:
+    default:
+      print_key: 'true'
+      get_value: '^.*interface (?<name>\S*)\n'
+  mac_notification_added:
+    default:
+      get_value: 'snmp trap mac-notification change added'
+      set_value: 'snmp trap mac-notification change added'
+      unset_value: 'no snmp trap mac-notification change added'
+      can_have_no_match: 'true'
+    exclusions:
+      - device: '2960'
+      - device: '4507'
+      - device: '6503'
+  mac_notification_removed:
+    default:
+      get_value: 'snmp trap mac-notification change removed'
+      set_value: 'snmp trap mac-notification change removed'
+      unset_value: 'no snmp trap mac-notification change removed'
+      can_have_no_match: 'true'
+    exclusions:
+      - device: '2960'
+      - device: '4507'
+      - device: '6503'
+  link_status_duplicates:
+    default:
+      get_value: 'snmp trap link-status permit duplicates'
+      set_value: 'snmp trap link-status permit duplicates'
+      unset_value: 'no snmp trap link-status permit duplicates'
+      can_have_no_match: 'true'
+  logging_event:
+    default:
+      get_value: '([^no]\s)logging event (?<logging_event>\S*)'
+      set_value: 'logging event <logging_event>'
+      can_have_no_match: 'true'
+  logging_event_link_status:
+    default:
+      get_value: 'no logging event link-status'
+      set_value: 'logging event link-status'
+      unset_value: 'no logging event link-status'
+      can_have_no_match: 'true'
+  ip_dhcp_snooping_trust:
+    default:
+      get_value: 'ip dhcp snooping trust'
+      set_value: 'ip dhcp snooping trust'
+      unset_value: 'no ip dhcp snooping trust'
+      can_have_no_match: 'true'
+    exclusions:
+      - device: '6503'
+  ip_dhcp_snooping_limit:
+    default:
+      get_value: 'ip dhcp snooping limit rate (?<ip_dhcp_snooping_limit>\S*)'
+      set_value: 'ip dhcp snooping limit rate <ip_dhcp_snooping_limit>'
+      unset_value: 'no ip dhcp snooping limit rate'
+      can_have_no_match: 'true'
+    exclusions:
+      - device: '6503'
+  flowcontrol_receive:
+    default:
+      get_value: 'flowcontrol receive (?<flowcontrol_receive>\S*)'
+      set_value: 'flowcontrol receive <flowcontrol_receive>'
+      can_have_no_match: 'true'

--- a/lib/puppet/provider/ios_network_dns/cisco_ios.rb
+++ b/lib/puppet/provider/ios_network_dns/cisco_ios.rb
@@ -33,10 +33,7 @@ class Puppet::Provider::IosNetworkDns::CiscoIos
       should[key] = Puppet::Provider::IosNetworkDns::CiscoIos.false_to_unset(should[key])
     end
     # this builds the command to set the domain-name
-    puts should
-    puts array_of_commands
     commands = array_of_commands + PuppetX::CiscoIOS::Utility.build_commmands_from_attribute_set_values(should, commands_hash)
-    puts commands
     commands
   end
 

--- a/lib/puppet/type/ios_interface.rb
+++ b/lib/puppet/type/ios_interface.rb
@@ -1,0 +1,46 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'ios_interface',
+  docs: 'Manage layer 3 configuration on a per Instance basis.',
+  features: ['remote_resource', 'canonicalize'],
+  attributes: {
+    name: {
+      type:      'String',
+      desc:      'The switch interface name, e.g. "Ethernet1"',
+      behaviour: :namevar,
+    },
+    mac_notification_added: {
+      type:    'Optional[Boolean]',
+      desc:    'Whether to enable Mac Address added notification for this port.',
+    },
+    mac_notification_removed: {
+      type:    'Optional[Boolean]',
+      desc:    'Whether to enable Mac Address removed notification for this port.',
+    },
+    link_status_duplicates: {
+      type:    'Optional[Boolean]',
+      desc:    'Whether to permit duplicate SNMP LINKUP and LINKDOWN traps.',
+    },
+    logging_event: {
+      type:   'Optional[Variant[Enum["unset"], Array[Enum["bundle-status","nfas-status","spanning-tree","status","subif-link-status","trunk-status","power-inline-status"]]]]',
+      desc:   'Whether or not to log certain event messages. Any event log not specifically indicated will be disabled.',
+    },
+    logging_event_link_status: {
+      type:   'Optional[Boolean]',
+      desc:   'Whether to log UPDOWN and CHANGE event messages.',
+    },
+    ip_dhcp_snooping_trust: {
+      type:   'Optional[Boolean]',
+      desc:   'DHCP Snooping trust config',
+    },
+    ip_dhcp_snooping_limit: {
+      type:    'Optional[Variant[Boolean[false], Integer[1, 2048]]]',
+      desc:   'DHCP snooping rate limit',
+    },
+    flowcontrol_receive: {
+      type:   'Optional[Enum["desired","on","off"]]',
+      desc:   'Flow control (receive) [desired|on|off]',
+    },
+  },
+)

--- a/spec/acceptance/ios_interface_spec.rb
+++ b/spec/acceptance/ios_interface_spec.rb
@@ -1,15 +1,18 @@
 require 'spec_helper_acceptance'
 
 describe 'ios_interface' do
-  target = if ['3650', '3750', '2960'].include?(device_model)
-             'GigabitEthernet1/0'
-           elsif ['4507', '4948', '6503'].include?(device_model)
-             'GigabitEthernet1'
-           elsif ['4503'].include?(device_model)
-             'GigabitEthernet2'
-           else
-             'GigabitEthernet0'
-           end
+  let(:target) do
+    if ['3650', '3750', '2960'].include?(device_model)
+      'GigabitEthernet1/0'
+    elsif ['4507', '4948', '6503'].include?(device_model)
+      'GigabitEthernet1'
+    elsif ['4503'].include?(device_model)
+      'GigabitEthernet2'
+    else
+      'GigabitEthernet0'
+    end
+  end
+
   it 'Set Two Instances' do
     mac = if ['2960', '4507', '6503'].include?(device_model)
             ['', '', '', '']

--- a/spec/acceptance/ios_interface_spec.rb
+++ b/spec/acceptance/ios_interface_spec.rb
@@ -1,0 +1,186 @@
+require 'spec_helper_acceptance'
+
+describe 'ios_interface' do
+  target = if ['3650', '3750', '2960'].include?(device_model)
+             'GigabitEthernet1/0'
+           elsif ['4507', '4948', '6503'].include?(device_model)
+             'GigabitEthernet1'
+           elsif ['4503'].include?(device_model)
+             'GigabitEthernet2'
+           else
+             'GigabitEthernet0'
+           end
+  it 'Set Two Instances' do
+    mac = if ['2960', '4507', '6503'].include?(device_model)
+            ['', '', '', '']
+          else
+            ['mac_notification_added => false,', 'mac_notification_removed => false,',
+             'mac_notification_added => true,', 'mac_notification_removed => true,']
+          end
+    ip = if ['6503'].include?(device_model)
+           ['', '', '', '']
+         else
+           ['ip_dhcp_snooping_trust => true,', 'ip_dhcp_snooping_limit => 500,',
+            'ip_dhcp_snooping_trust => false,', 'ip_dhcp_snooping_limit => 1500,']
+         end
+    pp = <<-EOS
+    ios_interface { '#{target}/1':
+      #{mac[0]}
+      #{mac[1]}
+      #{ip[0]}
+      #{ip[1]}
+      link_status_duplicates => true,
+      logging_event => ['nfas-status','subif-link-status'],
+      flowcontrol_receive => 'on',
+    }
+    ios_interface { '#{target}/2':
+      #{mac[2]}
+      #{mac[3]}
+      #{ip[2]}
+      #{ip[3]}
+      logging_event => ['trunk-status'],
+      logging_event_link_status => false,
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Check puppet resource
+    result = run_resource('ios_interface', "#{target}/1")
+    expect(result).to match(%r{mac_notification_added => false}) if mac[0] != ''
+    expect(result).to match(%r{mac_notification_removed => false}) if mac[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_trust => true}) if ip[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_limit => 500,}) if ip[0] != ''
+    expect(result).to match(%r{link_status_duplicates => true})
+    expect(result).to match(%r{logging_event => \['nfas-status', 'subif-link-status'\]})
+    expect(result).to match(%r{logging_event_link_status => true})
+    expect(result).to match(%r{flowcontrol_receive => 'on'}) if result =~ %r{flowcontrol_receive =>}
+    result = run_resource('ios_interface', "#{target}/2")
+    expect(result).to match(%r{mac_notification_added => true}) if mac[0] != ''
+    expect(result).to match(%r{mac_notification_removed => true}) if mac[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_trust => false}) if ip[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_limit => 1500,}) if ip[0] != ''
+    expect(result).to match(%r{link_status_duplicates => false})
+    expect(result).to match(%r{logging_event => \['trunk-status'\]})
+    expect(result).to match(%r{logging_event_link_status => false})
+    expect(result).to match(%r{flowcontrol_receive => 'off'}) if result =~ %r{flowcontrol_receive =>}
+    # Are we idempotent
+    run_device(allow_changes: false)
+  end
+
+  it 'Update Two Instances' do
+    mac = if ['2960', '4507', '6503'].include?(device_model)
+            ['', '', '', '']
+          else
+            ['mac_notification_added => true,', 'mac_notification_removed => true,',
+             'mac_notification_added => false,', 'mac_notification_removed => false,']
+          end
+    ip = if ['6503'].include?(device_model)
+           ['', '']
+         else
+           ['ip_dhcp_snooping_trust => false,', 'ip_dhcp_snooping_limit => 1500,',
+            'ip_dhcp_snooping_trust => true,', 'ip_dhcp_snooping_limit => 500,']
+         end
+    pp = <<-EOS
+    ios_interface { '#{target}/1':
+      #{mac[0]}
+      #{mac[1]}
+      #{ip[0]}
+      #{ip[1]}
+      link_status_duplicates => false,
+      logging_event => ['trunk-status'],
+      logging_event_link_status => true,
+      flowcontrol_receive => 'off',
+    }
+    ios_interface { '#{target}/2':
+      #{mac[2]}
+      #{mac[3]}
+      #{ip[2]}
+      #{ip[3]}
+      link_status_duplicates => true,
+      logging_event => ['nfas-status','subif-link-status'],
+      logging_event_link_status => false,
+      flowcontrol_receive => 'on',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Check puppet resource
+    result = run_resource('ios_interface', "#{target}/1")
+    expect(result).to match(%r{mac_notification_added => true}) if mac[0] != ''
+    expect(result).to match(%r{mac_notification_removed => true}) if mac[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_trust => false}) if ip[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_limit => 1500,}) if ip[0] != ''
+    expect(result).to match(%r{link_status_duplicates => false})
+    expect(result).to match(%r{logging_event => \['trunk-status'\]})
+    expect(result).to match(%r{logging_event_link_status => true})
+    expect(result).to match(%r{flowcontrol_receive => 'off'}) if result =~ %r{flowcontrol_receive =>}
+    result = run_resource('ios_interface', "#{target}/2")
+    expect(result).to match(%r{mac_notification_added => false}) if mac[0] != ''
+    expect(result).to match(%r{mac_notification_removed => false}) if mac[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_trust => true}) if ip[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_limit => 500}) if ip[0] != ''
+    expect(result).to match(%r{link_status_duplicates => true})
+    expect(result).to match(%r{logging_event => \['nfas-status', 'subif-link-status'\]})
+    expect(result).to match(%r{logging_event_link_status => false})
+    expect(result).to match(%r{flowcontrol_receive => 'on'}) if result =~ %r{flowcontrol_receive =>}
+    # Are we idempotent
+    run_device(allow_changes: false)
+  end
+
+  it 'Unset Two Instances' do
+    mac = if ['2960', '4507', '6503'].include?(device_model)
+            ['', '']
+          else
+            ['mac_notification_added => false,', 'mac_notification_removed => false,']
+          end
+    ip = if ['6503'].include?(device_model)
+           ['', '']
+         else
+           ['ip_dhcp_snooping_limit => false,', 'ip_dhcp_snooping_trust => false,']
+         end
+    pp = <<-EOS
+    ios_interface { '#{target}/1':
+      #{mac[0]}
+      #{mac[1]}
+      #{ip[0]}
+      #{ip[1]}
+      link_status_duplicates => false,
+      logging_event => 'unset',
+      logging_event_link_status => true,
+    }
+    ios_interface { '#{target}/2':
+      #{mac[0]}
+      #{mac[1]}
+      #{ip[0]}
+      #{ip[1]}
+      link_status_duplicates => false,
+      logging_event => 'unset',
+      logging_event_link_status => true,
+      flowcontrol_receive => 'off',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Check puppet resource
+    result = run_resource('ios_interface', "#{target}/1")
+    expect(result).to match(%r{mac_notification_added => false}) if mac[0] != ''
+    expect(result).to match(%r{mac_notification_removed => false}) if mac[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_trust => false}) if ip[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_limit => false}) if ip[0] != ''
+    expect(result).to match(%r{link_status_duplicates => false})
+    expect(result).to match(%r{logging_event => 'unset'})
+    expect(result).to match(%r{logging_event_link_status => true})
+    expect(result).to match(%r{flowcontrol_receive => 'off'}) if result =~ %r{flowcontrol_receive =>}
+    result = run_resource('ios_interface', "#{target}/2")
+    expect(result).to match(%r{mac_notification_added => false}) if mac[0] != ''
+    expect(result).to match(%r{mac_notification_removed => false}) if mac[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_trust => false}) if ip[0] != ''
+    expect(result).to match(%r{ip_dhcp_snooping_limit => false}) if ip[0] != ''
+    expect(result).to match(%r{link_status_duplicates => false})
+    expect(result).to match(%r{logging_event => 'unset'})
+    expect(result).to match(%r{logging_event_link_status => true})
+    expect(result).to match(%r{flowcontrol_receive => 'off'}) if result =~ %r{flowcontrol_receive =>}
+    # Are we idempotent
+    run_device(allow_changes: false)
+  end
+end

--- a/spec/unit/puppet/provider/ios_interface/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_interface/cisco_ios_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+module Puppet::Provider::IosInterface; end
+require 'puppet/provider/ios_interface/cisco_ios'
+
+RSpec.describe Puppet::Provider::IosInterface::CiscoIos do
+  let(:utility) { described_class }
+
+  def self.load_test_data
+    PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/test_data.yaml', false)
+  end
+
+  it_behaves_like 'resources parsed from cli'
+
+  context 'Update tests:' do
+    load_test_data['default']['update_tests'].each do |test_name, test|
+      it test_name.to_s do
+        fake_device(test['device'], test['family'])
+        if test['commands'].size.zero?
+          expect { described_class.commands_from_instance(test['instance'], test['current_instance']) }.to raise_error(%r{.*})
+        else
+          expect(described_class.commands_from_instance(test['instance'], test['current_instance'])).to eq test['commands']
+        end
+      end
+    end
+  end
+
+  describe 'false_to_unset' do
+    it 'given string' do
+      expect(utility.false_to_unset('cake')).to eq 'cake'
+    end
+    it 'given true' do
+      expect(utility.false_to_unset(true)).to eq true
+    end
+    it 'given false' do
+      expect(utility.false_to_unset(false)).to eq 'unset'
+    end
+  end
+
+  describe 'clean_logging_event' do
+    it 'given string' do
+      given = { logging_event: 'trunk-status' }
+      expected = { logging_event: ['trunk-status'] }
+      expect(utility.clean_logging_event(given)).to eq expected
+    end
+    it 'given string with link_status' do
+      given = { logging_event: 'link-status' }
+      expected = { logging_event: 'unset' }
+      expect(utility.clean_logging_event(given)).to eq expected
+    end
+    it 'given nil value' do
+      given = {}
+      expected = { logging_event: 'unset' }
+      expect(utility.clean_logging_event(given)).to eq expected
+    end
+    it 'given array' do
+      given = { logging_event: ['trunk-status'] }
+      expected = { logging_event: ['trunk-status'] }
+      expect(utility.clean_logging_event(given)).to eq expected
+    end
+    it 'given array with link_status' do
+      expect(utility.false_to_unset(true)).to eq true
+      given = { logging_event: ['link-status', 'trunk-status'] }
+      expected = { logging_event: ['trunk-status'] }
+      expect(utility.clean_logging_event(given)).to eq expected
+    end
+  end
+end

--- a/spec/unit/puppet/provider/ios_interface/test_data.yaml
+++ b/spec/unit/puppet/provider/ios_interface/test_data.yaml
@@ -1,0 +1,109 @@
+---
+default:
+  read_tests:
+    "show interface":
+      cli: "!\ninterface GigabitEthernet0/1\n no logging event link-status\n no logging event trunk-status\n logging event spanning-tree\n logging event subif-link-status\n snmp trap mac-notification change added\n flowcontrol receive desired\n ip dhcp snooping limit rate 1500\n ip dhcp snooping trust\n ip dhcp snooping information option allow-untrusted"
+      expectations:
+      - :name: 'GigabitEthernet0/1'
+        :flowcontrol_receive: 'desired'
+        :ip_dhcp_snooping_limit: 1500
+        :ip_dhcp_snooping_trust: true
+        :link_status_duplicates: false
+        :logging_event: ['spanning-tree','subif-link-status']
+        :logging_event_link_status: false
+        :mac_notification_added: true
+        :mac_notification_removed: false
+  update_tests:
+    "set":
+      commands:
+      - "logging event spanning-tree"
+      - "logging event subif-link-status"
+      - "no snmp trap mac-notification change added"
+      - "snmp trap mac-notification change removed"
+      - "snmp trap link-status permit duplicates"
+      - "flowcontrol receive on"
+      - "ip dhcp snooping limit rate 1500"
+      - "ip dhcp snooping trust"
+      - "no logging event link-status"
+      instance:
+        :name: 'Vlan4'
+        :mac_notification_added: false
+        :mac_notification_removed: true
+        :link_status_duplicates: true
+        :flowcontrol_receive: 'on'
+        :ip_dhcp_snooping_limit: 1500
+        :ip_dhcp_snooping_trust: true
+        :logging_event: ['spanning-tree','subif-link-status']
+        :logging_event_link_status: false
+      current_instance:
+        :name: 'Vlan4'
+        :mac_notification_added: false
+        :mac_notification_removed: false
+        :link_status_duplicates: false
+        :flowcontrol_receive: 'off'
+        :ip_dhcp_snooping_limit: false
+        :ip_dhcp_snooping_trust: false
+        :link_status: false
+        :logging_event_link_status: true
+    "update":
+      commands:
+      - "no logging event spanning-tree"
+      - "no logging event subif-link-status"
+      - "logging event trunk-status"
+      - "snmp trap mac-notification change added"
+      - "no snmp trap mac-notification change removed"
+      - "no snmp trap link-status permit duplicates"
+      - "flowcontrol receive desired"
+      - "ip dhcp snooping limit rate 500"
+      - "no ip dhcp snooping trust"
+      - "logging event link-status"
+      instance:
+        :name: 'Vlan4'
+        :mac_notification_added: true
+        :mac_notification_removed: false
+        :link_status_duplicates: false
+        :flowcontrol_receive: 'desired'
+        :ip_dhcp_snooping_limit: 500
+        :ip_dhcp_snooping_trust: false
+        :logging_event: ['trunk-status']
+        :logging_event_link_status: true
+      current_instance:
+        :name: 'Vlan4'
+        :mac_notification_added: false
+        :mac_notification_removed: true
+        :link_status_duplicates: true
+        :flowcontrol_receive: 'on'
+        :ip_dhcp_snooping_limit: 1500
+        :ip_dhcp_snooping_trust: true
+        :logging_event: ['spanning-tree','subif-link-status']
+        :logging_event_link_status: false
+    "unset":
+      commands:
+      - "no logging event trunk-status"
+      - "no snmp trap mac-notification change added"
+      - "no snmp trap mac-notification change removed"
+      - "no snmp trap link-status permit duplicates"
+      - "flowcontrol receive off"
+      - "no ip dhcp snooping limit rate"
+      - "no ip dhcp snooping trust"
+      - "logging event link-status"
+      instance:
+        :name: 'Vlan4'
+        :mac_notification_added: false
+        :mac_notification_removed: false
+        :link_status_duplicates: false
+        :flowcontrol_receive: 'off'
+        :ip_dhcp_snooping_limit: false
+        :ip_dhcp_snooping_trust: false
+        :logging_event: 'unset'
+        :logging_event_link_status: true
+      current_instance:
+        :name: 'Vlan4'
+        :mac_notification_added: true
+        :mac_notification_removed: false
+        :link_status_duplicates: false
+        :flowcontrol_receive: 'desired'
+        :ip_dhcp_snooping_limit: 500
+        :ip_dhcp_snooping_trust: false
+        :logging_event: ['trunk-status']
+        :logging_event_link_status: true

--- a/spec/unit/puppet/type/ios_interface.rb
+++ b/spec/unit/puppet/type/ios_interface.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+describe 'the ios_interface type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:ios_interface)).not_to be_nil
+  end
+end


### PR DESCRIPTION
 - name:  The switch interface name, e.g. "Ethernet1”
 - mac_notification_added: Whether to enable Mac Address added notification for this port.
 - mac_notification_removed: Whether to enable Mac Address removed notification for this port.
 - link_status: Whether to permit duplicate SNMP LINKUP and LINKDOWN traps.
 - logging_event: Whether or not to log certain event messages. Any event log not specifically indicated will be disabled.
 - logging_event_link_status: Whether to log UPDOWN and CHANGE event messages.
 - ip_dhcp_snooping_trust: DHCP Snooping trust config
 - ip_dhcp_snooping_limit: DHCP snooping rate limit
 - flowcontrol_receive: Flow control (receive) [desired|on|off]