### PR TITLE
(FM-8310) idempotency fixes for ios stp global

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,9 +1004,9 @@ The following properties are available in the `ios_stp_global` type.
 
 ##### `enable`
 
-Data type: `Optional[Boolean]`
+Data type: `Optional[Boolean[false]]`
 
-Enable or disable STP functionality [true|false]
+Disable STP functionality by specifying false.
 
 ##### `bridge_assurance`
 

--- a/lib/puppet/provider/ios_stp_global/command.yaml
+++ b/lib/puppet/provider/ios_stp_global/command.yaml
@@ -23,7 +23,7 @@ attributes:
       can_have_no_match: 'true'
   extend_system_id:
     default:
-      get_value: '(?:spanning-tree extend )(?<system-id>\S*)\\n'
+      get_value: '(?:spanning-tree extend )(?<system-id>\S*)'
       set_value: 'spanning-tree extend system-id'
       unset_value: 'no spanning-tree extend system-id'
       can_have_no_match: 'true'
@@ -119,9 +119,4 @@ attributes:
     default:
       get_value: '.*(?:(?:spanning-tree vlan (?<vlans>\S*)?) (?:priority (?<priority>[^\\n]*)\\n))'
       set_value: 'spanning-tree vlan <vlans> priority <priority>'
-      can_have_no_match: 'true'
-  enable:
-    default:
-      get_value: 'not used'
-      set_value: 'not used'
       can_have_no_match: 'true'

--- a/lib/puppet/type/ios_stp_global.rb
+++ b/lib/puppet/type/ios_stp_global.rb
@@ -12,8 +12,8 @@ Puppet::ResourceApi.register_type(
       behaviour: :namevar,
     },
     enable:  {
-      type:    'Optional[Boolean]',
-      desc:    'Enable or disable STP functionality [true|false]',
+      type:    'Optional[Boolean[false]]',
+      desc:    'Disable STP functionality by specifying false.',
     },
     bridge_assurance:      {
       type:    'Optional[Boolean]',


### PR DESCRIPTION
The `enable` property is something that is only implied so if trying to remove something, i.e. `enable => false` then the value is assigned to a variable and then the property is deleted from the resource in order to maintain idempotency.