### PR TITLE
(maint) fixes for the final ios_snmp_global idempotency failures

### DIFF
--- a/lib/puppet/provider/ios_snmp_global/cisco_ios.rb
+++ b/lib/puppet/provider/ios_snmp_global/cisco_ios.rb
@@ -14,6 +14,9 @@ class Puppet::Provider::IosSnmpGlobal::CiscoIos
     new_instance[:system_shutdown] = Puppet::Provider::IosSnmpGlobal::CiscoIos.convert_to_boolean(new_instance[:system_shutdown])
     new_instance[:manager] = Puppet::Provider::IosSnmpGlobal::CiscoIos.convert_to_boolean(new_instance[:manager])
     new_instance[:ifmib_ifindex_persist] = Puppet::Provider::IosSnmpGlobal::CiscoIos.convert_to_boolean(new_instance[:ifmib_ifindex_persist])
+    new_instance[:manager_session_timeout] = 'unset' unless new_instance[:manager_session_timeout]
+    new_instance[:contact] = 'unset' unless new_instance[:contact]
+    new_instance[:trap_source] = 'unset' unless new_instance[:trap_source]
     new_instance_fields << new_instance
     new_instance_fields
   end

--- a/spec/acceptance/ios_snmp_global_spec.rb
+++ b/spec/acceptance/ios_snmp_global_spec.rb
@@ -49,7 +49,7 @@ describe 'ios_snmp_global' do
     expect(result).to match(%r{system_shutdown => true})
     expect(result).to match(%r{contact => 'SNMP_TEST_TWO'})
     expect(result).to match(%r{manager => true})
-    expect(result).not_to match(%r{manager_session_timeout =>})
+    expect(result).to match(%r{manager_session_timeout => 'unset'})
     expect(result).to match(%r{ifmib_ifindex_persist => true})
   end
 
@@ -72,11 +72,11 @@ describe 'ios_snmp_global' do
     result = run_resource('ios_snmp_global', 'default')
     expect(result).to match(%r{default.*})
     # Default values
-    expect(result).not_to match(%r{trap_source =>})
+    expect(result).to match(%r{trap_source => 'unset'})
     expect(result).to match(%r{system_shutdown => false})
-    expect(result).not_to match(%r{contact =>})
+    expect(result).to match(%r{contact => 'unset'})
     expect(result).to match(%r{manager => false})
-    expect(result).not_to match(%r{manager_session_timeout =>})
+    expect(result).to match(%r{manager_session_timeout => 'unset'})
     expect(result).to match(%r{ifmib_ifindex_persist => false})
   end
 end

--- a/spec/unit/puppet/provider/ios_snmp_global/test_data.yaml
+++ b/spec/unit/puppet/provider/ios_snmp_global/test_data.yaml
@@ -8,6 +8,9 @@ default:
         :system_shutdown: false
         :manager: false
         :ifmib_ifindex_persist: false
+        :contact: 'unset'
+        :manager_session_timeout: 'unset'
+        :trap_source: 'unset'
   update_tests:
     "Set":
       commands:


### PR DESCRIPTION
Some of the values weren't returning `'unset'` when unmanaged causing idempotency issues. This PR will return the `'unset'` keyword when required.