### PR TITLE
(FM-7815) Merge functions of ios_access_list and ios_acl_entry

### DIFF
--- a/TestMatrix.md
+++ b/TestMatrix.md
@@ -26,6 +26,7 @@ The module works against a broad range of IOS and IOS-XE based devices, but we d
 |---------------------------------|----------------------|----------------------|----------------------|----------------------|----------------------|----------------------|----------------------|
 | banner                          | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | domain_name                     | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      |
+| ios_acl                         | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | ios_config                      | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | ios_radius_global               | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | ios_stp_global                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok                   |

--- a/TestMatrix.md
+++ b/TestMatrix.md
@@ -27,13 +27,13 @@ The module works against a broad range of IOS and IOS-XE based devices, but we d
 | banner                          | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | domain_name                     | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      |
 | ios_acl                         | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
-| ios_config                      | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
-| ios_radius_global               | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
-| ios_stp_global                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok                   |
 | ios_additional_syslog_settings  | ok                   | ok                   | ok                   | ok                   | ok                   | ok*                  | ok                   |
+| ios_config                      | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | ios_interface                   | ok*                  | ok                   | ok                   | ok*                  | ok*                  | ok                   | ok*                  |
 | ios_ntp_access_group            | ok*                  | ok                   | ok*                  | ok                   | ok*                  | ok*                  | ok*                  |
 | ios_ntp_config                  | ok*                  | ok*                  | ok*                  | ok                   | ok                   | ok                   | ok                   |
+| ios_radius_global               | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
+| ios_stp_global                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok*                  | ok                   |
 | name_server                     | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      | use network_dns      |
 | network_dns                     | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   | ok                   |
 | network_interface               | ok*                  | ok*                  | ok*                  | ok                   | ok                   | ok                   | ok                   |

--- a/lib/puppet/provider/ios_access_list/cisco_ios.rb
+++ b/lib/puppet/provider/ios_access_list/cisco_ios.rb
@@ -37,6 +37,7 @@ class Puppet::Provider::IosAccessList::CiscoIos
   end
 
   def get(context)
+    context.warning('The ios_access_list type is deprecated, due to unreconcilable implementation issues. Use the ios_acl type instead.')
     output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
     return [] if output.nil?
     instances_from_cli(output)

--- a/lib/puppet/provider/ios_access_list/cisco_ios.rb
+++ b/lib/puppet/provider/ios_access_list/cisco_ios.rb
@@ -33,13 +33,13 @@ class Puppet::Provider::IosAccessList::CiscoIos
   end
 
   def commands_hash
-    Puppet::Provider::IosAccessList::CiscoIos.commands_hash
+    self.class.commands_hash
   end
 
   def get(context)
     output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
     return [] if output.nil?
-    Puppet::Provider::IosAccessList::CiscoIos.instances_from_cli(output)
+    instances_from_cli(output)
   end
 
   def set(context, changes)
@@ -59,7 +59,7 @@ class Puppet::Provider::IosAccessList::CiscoIos
   end
 
   def update(context, _name, should)
-    array_of_commands_to_run = Puppet::Provider::IosAccessList::CiscoIos.commands_from_instance(should)
+    array_of_commands_to_run = commands_from_instance(should)
     array_of_commands_to_run.each do |command|
       context.transport.run_command_conf_t_mode(command)
     end
@@ -67,7 +67,7 @@ class Puppet::Provider::IosAccessList::CiscoIos
 
   def delete(context, _name, is)
     is[:ensure] = 'absent'
-    array_of_commands_to_run = Puppet::Provider::IosAccessList::CiscoIos.commands_from_instance(is)
+    array_of_commands_to_run = commands_from_instance(is)
     array_of_commands_to_run.each do |command|
       context.transport.run_command_conf_t_mode(command)
     end

--- a/lib/puppet/provider/ios_acl/cisco_ios.rb
+++ b/lib/puppet/provider/ios_acl/cisco_ios.rb
@@ -1,8 +1,8 @@
 require_relative '../../util/network_device/cisco_ios/device'
 require_relative '../../../puppet_x/puppetlabs/cisco_ios/utility'
 
-# Configure Access List Entries on the device
-class Puppet::Provider::IosAclEntry::CiscoIos
+# Configure Access Lists on the device
+class Puppet::Provider::IosAcl::CiscoIos
   def self.commands_hash
     @commands_hash ||= PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/command.yaml')
   end
@@ -144,11 +144,13 @@ class Puppet::Provider::IosAclEntry::CiscoIos
         instance[:match_all] = []
         while split_output[0][0] == '-' || split_output[0][0] == '+'
           instance[:match_all] << split_output.shift
+          break if split_output.empty?
         end
       elsif next_token == 'match-any'
         instance[:match_any] = []
         while split_output[0][0] == '-' || split_output[0][0] == '+'
           instance[:match_any] << split_output.shift
+          break if split_output.empty?
         end
       elsif next_token == 'option'
         instance[:option] = split_output.shift
@@ -194,7 +196,7 @@ class Puppet::Provider::IosAclEntry::CiscoIos
   end
 
   def self.type_of_access_list(output)
-    output.scan(%r{(\S*) IP access list.*}).flatten.first
+    output.scan(%r{(\S*) IP access list.*}).flatten.first.downcase
   end
 
   def self.name_of_access_list(output)
@@ -215,7 +217,7 @@ class Puppet::Provider::IosAclEntry::CiscoIos
 
         next_token = split_output.shift
         next unless next_token =~ %r{^\d+$}
-        new_instance[:entry] = next_token.to_i
+        new_instance[:entry] = next_token
         next_token = split_output.shift
 
         if next_token.casecmp('dynamic').zero?
@@ -227,11 +229,12 @@ class Puppet::Provider::IosAclEntry::CiscoIos
         if new_instance[:permission].casecmp('evaluate').zero?
           new_instance[:evaluation_name] = split_output.shift
         end
-        new_instance[:name] = "#{acl_name} #{new_instance[:entry]}"
+        new_instance[:title] = "#{acl_name} #{acl_type} #{new_instance[:entry]}"
         new_instance[:access_list] = acl_name
+        new_instance[:access_list_type] = acl_type
         new_instance[:ensure] = 'present'
 
-        new_instance = if acl_type != 'Extended' && !new_instance[:permission].casecmp('evaluate').zero?
+        new_instance = if acl_type != 'extended' && !new_instance[:permission].casecmp('evaluate').zero?
                          parse_standard(split_output, new_instance)
                        else
                          parse_extended(split_output, new_instance)
@@ -248,21 +251,21 @@ class Puppet::Provider::IosAclEntry::CiscoIos
     commands = []
 
     # some validation
-    if instance[:acl_type] == 'extended'
-      raise "ios_acl_entry requires 'source_address_wildcard_mask' to be set alongside 'source_address' " if (!instance[:source_address].nil? && instance[:source_address_wildcard_mask].nil?) ||
-                                                                                                             (instance[:source_address].nil? && !instance[:source_address_wildcard_mask].nil?)
-      raise "ios_acl_entry requires 'destination_address_wildcard_mask' to be set alongside 'destination_address' " if (!instance[:destination_address].nil? &&
+    if instance[:access_list_type] == 'extended'
+      raise "ios_acl requires 'source_address_wildcard_mask' to be set alongside 'source_address' " if (!instance[:source_address].nil? && instance[:source_address_wildcard_mask].nil?) ||
+                                                                                                       (instance[:source_address].nil? && !instance[:source_address_wildcard_mask].nil?)
+      raise "ios_acl requires 'destination_address_wildcard_mask' to be set alongside 'destination_address' " if (!instance[:destination_address].nil? &&
                                                                                                                         instance[:destination_address_wildcard_mask].nil?) ||
-                                                                                                                       (instance[:destination_address].nil? &&
-                                                                                                                        !instance[:destination_address_wildcard_mask].nil?)
+                                                                                                                 (instance[:destination_address].nil? &&
+                                                                                                                  !instance[:destination_address_wildcard_mask].nil?)
       raise 'Either Source Address, address object-group, any or source host are required.' if instance[:source_address].nil? &&
                                                                                                instance[:source_address_group].nil? &&
                                                                                                instance[:source_address_any].nil? &&
                                                                                                instance[:source_address_host].nil? && !instance[:permission].casecmp('evaluate').zero?
       raise 'Either log or log_input can be set, but not both' if !instance[:log].nil? && !instance[:log_input].nil?
       raise 'reflect_timeout requires reflect entry to be set' if !instance[:relect_timeout].nil? && instance[:relfect].nil?
-      raise 'protocol must be icmp to set icmp_message_type' if !instance[:protocol].casecmp('icmp') && instance[:icmp_message_type]
-      raise 'protocol must be igmp to set igmp_message_type' if !instance[:protocol].casecmp('igmp') && instance[:igmp_message_type]
+      raise 'protocol must be icmp to set icmp_message_type' if instance[:protocol] && !instance[:protocol].casecmp('icmp') && instance[:icmp_message_type]
+      raise 'protocol must be igmp to set igmp_message_type' if instance[:protocol] && !instance[:protocol].casecmp('igmp') && instance[:igmp_message_type]
     end
 
     unless instance[:icmp_message_type].to_s =~ %r{(^\d+$)}
@@ -404,7 +407,7 @@ class Puppet::Provider::IosAclEntry::CiscoIos
   end
 
   def commands_hash
-    commands_hash
+    self.class.commands_hash
   end
 
   def get(context)
@@ -415,47 +418,63 @@ class Puppet::Provider::IosAclEntry::CiscoIos
 
   def set(context, changes)
     changes.each do |name, change|
-      # What type of ACL are we using
-      access_list_output = context.transport.run_command_enable_mode("show ip access-lists #{change[:should][:access_list]}")
-      if name_of_access_list(access_list_output).nil?
-        raise "ios_acl_entry #{change[:should][:name]} requires parent ios_access_list #{change[:should][:access_list]} to be already present"
-      end
-      acl_type = type_of_access_list(access_list_output)
-
       is = change.key?(:is) ? change[:is] : (get(context) || []).find { |key| key[:name] == name }
       should = change[:should]
       if should[:ensure].to_s == 'absent'
         context.deleting(name) do
-          delete(context, name, acl_type, is)
+          delete(context, name, is)
         end
       else
         context.updating(name) do
-          update(context, name, acl_type, is, should)
+          update(context, name, is, should)
         end
       end
     end
   end
 
-  def update(context, name, acl_type, is, should)
-    should[:acl_type] = acl_type
+  def update(context, name, is, should)
     if is[:ensure] == 'present'
-      delete(context, name, acl_type, is)
+      delete(context, name, is)
     end
     array_of_commands_to_run = commands_from_instance(should)
     array_of_commands_to_run.each do |command|
-      context.transport.run_command_acl_mode(should[:access_list], acl_type, command)
+      context.transport.run_command_acl_mode(should[:access_list], should[:access_list_type], command)
     end
   end
 
-  def delete(context, _name, acl_type, is)
-    delete_instance = {}
-    delete_instance[:ensure] = 'absent'
-    delete_instance[:acl_type] = acl_type
-    delete_instance[:access_list] = is[:access_list]
-    delete_instance[:entry] = is[:entry]
-    array_of_commands_to_run = commands_from_instance(delete_instance)
+  def delete(context, _name, is)
+    is[:ensure] = 'absent'
+    # this will delete the entry
+    array_of_commands_to_run = commands_from_instance(is)
     array_of_commands_to_run.each do |command|
-      context.transport.run_command_acl_mode(delete_instance[:access_list], acl_type, command)
+      context.transport.run_command_acl_mode(is[:access_list], is[:access_list_type], command)
     end
+
+    # Check if this was the last entry that used the access list
+    command_line = PuppetX::CiscoIOS::Utility.value_foraged_from_command_hash(commands_hash, 'cleanup_check')
+    command = PuppetX::CiscoIOS::Utility.insert_attribute_into_command_line(command_line, 'access_list', is[:access_list], false)
+    check = context.transport.run_command_enable_mode(command)
+    count = check.match(%r{Number of lines which match regexp = (\d)$}).captures
+
+    # when the regex matches just the access list, a value of 2 is returned.
+    return unless count[0].to_i == 2
+
+    # this will delete the access list
+    command_line = PuppetX::CiscoIOS::Utility.value_foraged_from_command_hash(commands_hash, 'delete_command_default')
+    command = PuppetX::CiscoIOS::Utility.insert_attribute_into_command_line(command_line, 'access_list_type', is[:access_list_type], false)
+    command = PuppetX::CiscoIOS::Utility.insert_attribute_into_command_line(command, 'access_list', is[:access_list], false)
+    context.transport.run_command_conf_t_mode(command)
+  end
+
+  def canonicalize(_context, resources)
+    # if the puppet file contains an optional boolean with a false,
+    # remove it so that we don't break idempotency i.e. <blank> changed to 'false'
+    bool_attrs = [:source_address_any, :destination_address_any, :ack, :fin, :fragments, :log, :log_input, :psh, :rst, :urg]
+    resources.each do |resource|
+      bool_attrs.each do |attr|
+        resource.reject! { |key| key == attr && resource[key] == false }
+      end
+    end
+    resources
   end
 end

--- a/lib/puppet/provider/ios_acl/command.yaml
+++ b/lib/puppet/provider/ios_acl/command.yaml
@@ -1,0 +1,21 @@
+---
+get_values:
+  default: 'show ip access-lists'
+get_instances:
+  default: '\S* IP access list (?:(?:.| |\n )*\n)'
+set_values:
+  default: '<entry> <dynamic> <permission> <protocol> <source_address> <source_address_wildcard_mask> <source_address_group> <source_address_any> <source_address_host> <source_eq> <source_gt> <source_lt> <source_neq> <source_portgroup> <source_range> <destination_address> <destination_address_wildcard_mask> <destination_address_group> <destination_address_any> <destination_address_host> <destination_eq> <destination_gt> <destination_lt> <destination_neq> <destination_portgroup> <destination_range> <icmp_message_type> <icmp_message_code> <igmp_message_type> <ack> <dscp> <fin> <fragments> <log> <log_input> <match_all> <match_any> <option> <precedence> <psh> <reflect> <reflect_timeout> <rst> <syn> <time_range> <tos> <urg>'
+cleanup_check:
+  default: 'show ip access-list <access_list> | count .*'
+delete_command_default:
+  default: 'no ip access-list <access_list_type> <access_list>'
+attributes:
+  access_list_type:
+    default:
+      get_value: '(\S*) IP access list.*'
+  access_list:
+    default:
+      get_value: '.*IP access list\s+(\S+)'
+  evaluation_name:
+   default:
+     set_value: '<entry> evaluate <evaluation_name>'

--- a/lib/puppet/provider/ios_acl_entry/cisco_ios.rb
+++ b/lib/puppet/provider/ios_acl_entry/cisco_ios.rb
@@ -408,6 +408,7 @@ class Puppet::Provider::IosAclEntry::CiscoIos
   end
 
   def get(context)
+    context.warning('The ios_acl_entry type is deprecated, due to unreconcilable implementation issues. Use the ios_acl type instead.')
     output = context.transport.run_command_enable_mode(PuppetX::CiscoIOS::Utility.get_values(commands_hash))
     return [] if output.nil?
     PuppetX::CiscoIOS::Utility.enforce_simple_types(context, instances_from_cli(output))

--- a/lib/puppet/transport/cisco_ios.rb
+++ b/lib/puppet/transport/cisco_ios.rb
@@ -362,7 +362,7 @@ module Puppet::Transport
 
     def run_command_acl_mode(acl_name, acl_type, command)
       conf_acl_cmd = "ip access-list #{acl_type} #{acl_name}"
-      modestate_type = if acl_type == 'Extended'
+      modestate_type = if acl_type == 'extended'
                          ModeState::CONF_EXT_NACL
                        else
                          ModeState::CONF_STD_NACL

--- a/lib/puppet/type/ios_access_list.rb
+++ b/lib/puppet/type/ios_access_list.rb
@@ -2,7 +2,7 @@ require 'puppet/resource_api'
 
 Puppet::ResourceApi.register_type(
   name: 'ios_access_list',
-  docs: 'Configure access list on device',
+  docs: 'Configure access lists. Deprecated, due to unreconcilable implementation issues. Use the ios_acl type instead.',
   features: ['remote_resource'],
   attributes: {
     name:         {

--- a/lib/puppet/type/ios_acl.rb
+++ b/lib/puppet/type/ios_acl.rb
@@ -1,0 +1,223 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'ios_acl',
+  docs: 'Manage ACL contents',
+  features: ['remote_resource', 'canonicalize'],
+  title_patterns: [
+    {
+      pattern: %r{^(?<access_list>.*[^\s])\s(?<access_list_type>.*[^\s])\s(?<entry>.*)$},
+      desc: 'Made up of access_list and the entry with a space separator. e.g. "list42 standard 10" is from access list list42 and entry 10.',
+    },
+  ],
+  attributes: {
+    ensure:      {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this access list entry should be present or absent on the target system.',
+      default: 'present',
+    },
+    access_list:   {
+      type:    'String',
+      desc:    'Name of parent access list',
+      behaviour: :namevar,
+    },
+    entry:    {
+      type:    'String',
+      desc:    'Name. Used as sequence number <1-2147483647>',
+      behaviour: :namevar,
+    },
+    access_list_type:      {
+      type:    'Enum["standard","extended","reflexive","none"]',
+      desc:    'Type of access list - standard, extended, reflexive or no type',
+      behaviour: :namevar,
+    },
+    dynamic:         {
+      type:    'Optional[String]',
+      desc:    'Name of a Dynamic list',
+    },
+    permission:      {
+      type:    'Enum["permit", "deny", "evaluate"]',
+      desc:    'Specify packets to forward/reject, or evaluate an access list',
+    },
+    evaluation_name:     {
+      type:    'Optional[String]',
+      desc:    'Evaluate an access list',
+    },
+    protocol:    {
+      type:    'Optional[Variant[Enum["ahp","eigrp","esp","gre","icmp","igmp","ip","ipinip","nos","ospf","pcp","pim","tcp","udp"],Pattern[/\d+/]]]',
+      desc:    'ACL Entry Protocol',
+    },
+    source_address:   {
+      type:    'Optional[String]',
+      desc:    'Source Address. Either Source Address, address object-group, any or source host are required.',
+    },
+    source_address_group:   {
+      type:    'Optional[String]',
+      desc:    'Source Address object-group. Either Source Address, address object-group, any or source host are required.',
+    },
+    source_address_any:   {
+      type:    'Optional[Boolean]',
+      desc:    'Source Address. Either Source Address, address object-group, any or source host are required.',
+    },
+    source_address_host:   {
+      type:    'Optional[String]',
+      desc:    'Source Address. Either Source Address, address object-group, any or source host are required.',
+    },
+    source_address_wildcard_mask:   {
+      type:    'Optional[String]',
+      desc:    'Source Address wildcard mask. Must be used with, and only used with, Source Address.',
+    },
+    source_eq:   {
+      type:    'Optional[Array[String]]',
+      desc:    'Match only packets on a given port number.',
+    },
+    source_gt:   {
+      type:    'Optional[String]',
+      desc:    'Match only packets with a greater port number.',
+    },
+    source_lt:   {
+      type:    'Optional[String]',
+      desc:    'Match only packets with a lower port number.',
+    },
+    source_neq:   {
+      type:    'Optional[String]',
+      desc:    'Match only packets not on a given port number.',
+    },
+    source_portgroup:   {
+      type:    'Optional[String]',
+      desc:    'Destination port object-group.',
+    },
+    source_range:   {
+      type:    'Optional[Array[String]]',
+      desc:    'Match only packets in the range of port numbers.',
+    },
+    destination_address:   {
+      type:    'Optional[String]',
+      desc:    'Destination Address. Either Destination Address, address object-group, any or destination host are required.',
+    },
+    destination_address_group:   {
+      type:    'Optional[String]',
+      desc:    'Destination Address object-group. Either Destination Address, address object-group, any or destination host are required.',
+    },
+    destination_address_any:   {
+      type:    'Optional[Boolean]',
+      desc:    'Destination Address. Either Destination Address, address object-group, any or destination host are required.',
+    },
+    destination_address_host:   {
+      type:    'Optional[String]',
+      desc:    'Destination Address. Either Destination Address, address object-group, any or destination host are required.',
+    },
+    destination_address_wildcard_mask:   {
+      type:    'Optional[String]',
+      desc:    'Destination Address wildcard mask. Must be used with, and only used with, Destination Address.',
+    },
+    destination_eq:   {
+      type:    'Optional[Array[String]]',
+      desc:    'Match only packets on a given port number.',
+    },
+    destination_gt:   {
+      type:    'Optional[String]',
+      desc:    'Match only packets with a greater port number.',
+    },
+    destination_lt:   {
+      type:    'Optional[String]',
+      desc:    'Match only packets with a lower port number.',
+    },
+    destination_neq:   {
+      type:    'Optional[String]',
+      desc:    'Match only packets not on a given port number.',
+    },
+    destination_portgroup:   {
+      type:    'Optional[String]',
+      desc:    'Destination port object-group.',
+    },
+    destination_range:   {
+      type:    'Optional[Array[String]]',
+      desc:    'Match only packets in the range of port numbers.',
+    },
+    ack:   {
+      type:    'Optional[Boolean]',
+      desc:    'Match on the ACK bit.',
+    },
+    dscp:   {
+      type:    'Optional[String]',
+      desc:    'Match packets with given dscp value.',
+    },
+    fin:   {
+      type:    'Optional[Boolean]',
+      desc:    'Match on the FIN bit.',
+    },
+    fragments:   {
+      type:    'Optional[Boolean]',
+      desc:    'Check non-initial fragments.',
+    },
+    icmp_message_code:  {
+      type:    'Optional[Integer]',
+      desc:    'ICMP message code.',
+    },
+    icmp_message_type:  {
+      type:    'Optional[Variant[String, Integer]]',
+      desc:    'ICMP message type.',
+    },
+    igmp_message_type:  {
+      type:    'Optional[Variant[String, Integer]]',
+      desc:    'IGMP message type.',
+    },
+    log:   {
+      type:    'Optional[Boolean]',
+      desc:    'Log matches against this entry. Either log or log_input can be used, but not both.',
+    },
+    log_input:   {
+      type:    'Optional[Boolean]',
+      desc:    'Log matches against this entry, including input interface. Either log or log_input can be used, but not both.',
+    },
+    match_all:   {
+      type:    'Optional[Array[String]]',
+      desc:    'Match if all specified flags are present.',
+    },
+    match_any:   {
+      type:    'Optional[Array[String]]',
+      desc:    'Match if any specified flags are present.',
+    },
+    option:   {
+      type:    'Optional[String]',
+      desc:    'Match packets with given IP Options value.',
+    },
+    precedence:   {
+      type:    'Optional[String]',
+      desc:    'Match packets with given precedence value.',
+    },
+    psh:   {
+      type:    'Optional[Boolean]',
+      desc:    'Match on the PSH bit.',
+    },
+    reflect:   {
+      type:    'Optional[String]',
+      desc:    'Create reflexive access list entry.',
+    },
+    reflect_timeout:   {
+      type:    'Optional[Integer]',
+      desc:    'Maximum time to live in seconds. Only to be used with reflect.',
+    },
+    rst:   {
+      type:    'Optional[Boolean]',
+      desc:    'Match on the RST bit.',
+    },
+    syn:   {
+      type:    'Optional[Boolean]',
+      desc:    'Match on the SYN bit.',
+    },
+    time_range:   {
+      type:    'Optional[String]',
+      desc:    'Specify a time-range.',
+    },
+    tos:   {
+      type:    'Optional[String]',
+      desc:    'Match packets with given TOS value.',
+    },
+    urg:   {
+      type:    'Optional[Boolean]',
+      desc:    'Match on the URG bit.',
+    },
+  },
+)

--- a/lib/puppet/type/ios_acl_entry.rb
+++ b/lib/puppet/type/ios_acl_entry.rb
@@ -2,7 +2,7 @@ require 'puppet/resource_api'
 
 Puppet::ResourceApi.register_type(
   name: 'ios_acl_entry',
-  docs: 'An entry for ACL',
+  docs: 'Configure access lists entries. Deprecated, due to unreconcilable implementation issues. Use the ios_acl type instead.',
   features: ['remote_resource'],
   attributes: {
     name:         {

--- a/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
+++ b/lib/puppet_x/puppetlabs/cisco_ios/utility.rb
@@ -512,6 +512,7 @@ module PuppetX::CiscoIOS
     def self.enforce_simple_types(context, return_value)
       return_value.each do |individual_value_hash|
         individual_value_hash.each do |k, v|
+          next if k == :title
           type_to_use = context.type.definition[:attributes][k][:type]
 
           string_t = Puppet::Pops::Types::TypeFactory.string

--- a/spec/acceptance/ios_acl_spec.rb
+++ b/spec/acceptance/ios_acl_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper_acceptance'
+
+describe 'ios_acl' do
+  it 'apply access list entries' do
+    pp = <<-EOS
+    ios_acl { '12 standard 10':
+      permission => 'permit',
+      ensure => 'present',
+      source_address_any => true,
+    }
+    ios_acl { 'test42 standard 10':
+      permission => 'deny',
+      ensure => 'present',
+      source_address => '1.2.3.4',
+    }
+    ios_acl { 'test43 extended 30':
+      permission => 'deny',
+      ensure => 'present',
+      protocol => 'tcp',
+      source_address => '1.1.1.0',
+      source_address_wildcard_mask => '0.0.0.1',
+      destination_address => '0.2.4.2',
+      destination_address_wildcard_mask => '1.1.1.1',
+      match_all => ['+ack', '-fin'],
+      log => true,
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_acl', "'12 standard 10'")
+    expect(result).to match(%r{entry.*10})
+    expect(result).to match(%r{permission.*permit})
+    expect(result).to match(%r{access_list.*12})
+    expect(result).to match(%r{access_list_type.*standard})
+    expect(result).to match(%r{ensure.*present})
+    expect(result).to match(%r{source_address_any.*true})
+    result = run_resource('ios_acl', "'test42 standard 10'")
+    expect(result).to match(%r{entry.*10})
+    expect(result).to match(%r{permission.*deny})
+    expect(result).to match(%r{access_list.*test42})
+    expect(result).to match(%r{access_list_type.*standard})
+    expect(result).to match(%r{ensure.*present})
+    expect(result).to match(%r{source_address.*1.2.3.4})
+    result = run_resource('ios_acl', "'test43 extended 30'")
+    expect(result).to match(%r{entry.*30})
+    expect(result).to match(%r{permission.*deny})
+    expect(result).to match(%r{access_list.*test43})
+    expect(result).to match(%r{access_list_type.*extended})
+    expect(result).to match(%r{ensure.*present})
+    expect(result).to match(%r{protocol.*tcp})
+    expect(result).to match(%r{source_address.*1.1.1.0})
+    expect(result).to match(%r{source_address_wildcard_mask.*0.0.0.1})
+    expect(result).to match(%r{destination_address.*0.2.4.2})
+    expect(result).to match(%r{destination_address_wildcard_mask.*1.1.1.1})
+    expect(result).to match(%r{match_all.*\+ack.*-fin})
+    expect(result).to match(%r{log.*true})
+  end
+
+  it 'modify access list entries' do
+    pp = <<-EOS
+    ios_acl { '12 standard 10':
+      permission => 'deny',
+      ensure => 'present',
+      source_address_any => true,
+    }
+    ios_acl { 'test42 standard 10':
+      permission => 'permit',
+      ensure => 'present',
+      source_address => '4.3.2.1',
+    }
+    ios_acl { 'test43 extended 30':
+      permission => 'permit',
+      ensure => 'present',
+      protocol => 'tcp',
+      source_address => '3.3.3.1',
+      source_address_wildcard_mask => '0.0.0.254',
+      destination_address => '5.5.4.1',
+      destination_address_wildcard_mask => '0.0.1.254',
+      match_all => ['+ack'],
+      log => false,
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_acl', "'12 standard 10'")
+    expect(result).to match(%r{entry.*10})
+    expect(result).to match(%r{permission.*deny})
+    expect(result).to match(%r{access_list.*12})
+    expect(result).to match(%r{access_list_type.*standard})
+    expect(result).to match(%r{ensure.*present})
+    expect(result).to match(%r{source_address_any.*true})
+    result = run_resource('ios_acl', "'test42 standard 10'")
+    expect(result).to match(%r{entry.*10})
+    expect(result).to match(%r{permission.*permit})
+    expect(result).to match(%r{access_list.*test42})
+    expect(result).to match(%r{access_list_type.*standard})
+    expect(result).to match(%r{ensure.*present})
+    expect(result).to match(%r{source_address.*4.3.2.1})
+    result = run_resource('ios_acl', "'test43 extended 30'")
+    expect(result).to match(%r{entry.*30})
+    expect(result).to match(%r{permission.*permit})
+    expect(result).to match(%r{access_list.*test43})
+    expect(result).to match(%r{access_list_type.*extended})
+    expect(result).to match(%r{ensure.*present})
+    expect(result).to match(%r{protocol.*tcp})
+    expect(result).to match(%r{source_address.*3.3.3.1})
+    expect(result).to match(%r{source_address_wildcard_mask.*0.0.0.254})
+    expect(result).to match(%r{destination_address.*5.5.4.1})
+    expect(result).to match(%r{destination_address_wildcard_mask.*0.0.1.254})
+    expect(result).to match(%r{match_all.*\+ack})
+    expect(result).not_to match(%r{match_all.*\-fin})
+    expect(result).to match(%r{log.*false})
+  end
+
+  it 'remove access list entries' do
+    pp = <<-EOS
+    ios_acl { '12 standard 10':
+      ensure => 'absent'
+    }
+    ios_acl { 'test42 standard 10':
+      ensure => 'absent'
+    }
+    ios_acl { 'test43 extended 30':
+      ensure => 'absent',
+    }
+    EOS
+    make_site_pp(pp)
+    run_device(allow_changes: true)
+    # Are we idempotent
+    run_device(allow_changes: false)
+    # Check puppet resource
+    result = run_resource('ios_acl', "'12 standard 10'")
+    expect(result).to match(%r{ensure.*absent})
+    result = run_resource('ios_acl', "'test42 standard 10'")
+    expect(result).to match(%r{ensure.*absent})
+    result = run_resource('ios_acl', "'test43 extended 30'")
+    expect(result).to match(%r{ensure.*absent})
+  end
+end

--- a/spec/unit/puppet/provider/ios_acl/cisco_ios_spec.rb
+++ b/spec/unit/puppet/provider/ios_acl/cisco_ios_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+module Puppet::Provider::IosAcl; end
+require 'puppet/provider/ios_acl/cisco_ios'
+
+RSpec.describe Puppet::Provider::IosAcl::CiscoIos do
+  def self.load_test_data
+    PuppetX::CiscoIOS::Utility.load_yaml(File.expand_path(__dir__) + '/test_data.yaml', false)
+  end
+
+  it_behaves_like 'resources parsed from cli'
+  it_behaves_like 'commands created from instance'
+end

--- a/spec/unit/puppet/provider/ios_acl/test_data.yaml
+++ b/spec/unit/puppet/provider/ios_acl/test_data.yaml
@@ -1,0 +1,759 @@
+---
+default:
+  read_tests:
+    "DT config":
+      cli: "show ip access-lists\nExtended IP access list test1\n      10 permit tcp 192.168.10.0 0.0.0.255 any eq 22 log\n      20 permit udp 192.168.10.0 0.0.0.255 any\n      30 deny ip any any log\ncisco-c6503e#"
+      expectations:
+      - :title: 'test1 extended 10'
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :log: true
+        :entry: '10'
+        :source_address: '192.168.10.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :destination_eq: ['22']
+      - :title: 'test1 extended 20'
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'udp'
+        :entry: '20'
+        :source_address: '192.168.10.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+      - :title: 'test1 extended 30'
+        :ensure: 'present'
+        :permission: 'deny'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'ip'
+        :entry: '30'
+        :source_address_any: true
+        :destination_address_any: true
+        :log: true
+    "Dynamic list test 1":
+      cli: "show ip access-lists\nExtended IP access list test\n    4 Dynamic eek permit ip any 192.168.0.0 0.0.255.255 log\ncisco-c6503e#"
+      expectations:
+      - :title: 'test extended 4'
+        :ensure: 'present'
+        :dynamic: 'eek'
+        :permission: 'permit'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :protocol: 'ip'
+        :log: true
+        :entry: '4'
+        :source_address_any: true
+        :destination_address: '192.168.0.0'
+        :destination_address_wildcard_mask: '0.0.255.255'
+    "Dynamic list test 2":
+      cli: "show ip access-lists\nExtended IP access list 120\n    10 Dynamic testlist permit ip any any log\n       permit ip host 171.68.109.64 any log\n       permit ip host 171.68.109.158 any log\n    20 permit tcp any host 171.68.117.189 eq telnet (288 matches)\ncisco-c6503e#"
+      expectations:
+      - :title: '120 extended 10'
+        :ensure: 'present'
+        :entry: '10'
+        :dynamic: 'testlist'
+        :permission: 'permit'
+        :access_list: '120'
+        :access_list_type: 'extended'
+        :protocol: 'ip'
+        :log: true
+        :source_address_any: true
+        :destination_address_any: true
+      - :title: '120 extended 20'
+        :ensure: 'present'
+        :entry: '20'
+        :permission: 'permit'
+        :access_list: '120'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :source_address_any: true
+        :destination_address_host: '171.68.117.189'
+        :destination_eq: ['telnet']
+    "Test config":
+      cli: "show ip access-lists\nStandard IP access list test2\n    10 deny   1.2.3.4\nExtended IP access list test1\n    10 permit tcp any any log\n    20 deny pcp any any log\n    24 deny ip host 5.4.3.2 host 4.5.6.7 option ssr\n    30 deny tcp 1.0.1.4 4.3.2.1 0.2.4.2 1.1.1.1 match-all +ack -fin log-input\n    40 deny tcp any eq 22 telnet any eq 37 whois\ncisco-c6503e#"
+      expectations:
+      - :title: 'test2 standard 10'
+        :ensure: 'present'
+        :entry: '10'
+        :permission: 'deny'
+        :access_list: 'test2'
+        :access_list_type: 'standard'
+        :source_address: '1.2.3.4'
+      - :title: 'test1 extended 10'
+        :ensure: 'present'
+        :entry: '10'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :source_address_any: true
+        :destination_address_any: true
+        :log: true
+      - :title: 'test1 extended 20'
+        :ensure: 'present'
+        :entry: '20'
+        :permission: 'deny'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'pcp'
+        :source_address_any: true
+        :destination_address_any: true
+        :log: true
+      - :title: 'test1 extended 24'
+        :ensure: 'present'
+        :entry: '24'
+        :permission: 'deny'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'ip'
+        :source_address_host: '5.4.3.2'
+        :destination_address_host: '4.5.6.7'
+        :option: 'ssr'
+      - :title: 'test1 extended 30'
+        :ensure: 'present'
+        :entry: '30'
+        :permission: 'deny'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :source_address: '1.0.1.4'
+        :source_address_wildcard_mask: '4.3.2.1'
+        :destination_address: '0.2.4.2'
+        :destination_address_wildcard_mask: '1.1.1.1'
+        :match_all: ['+ack', '-fin']
+        :log_input: true
+      - :title: 'test1 extended 40'
+        :ensure: 'present'
+        :entry: '40'
+        :permission: 'deny'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :source_address_any: true
+        :source_eq: ['22', 'telnet']
+        :destination_address_any: true
+        :destination_eq: ['37', 'whois']
+    "Test config 2":
+      cli: "show ip access-lists\nExtended IP access list test\n    10 permit udp 0.0.0.0 255.255.255.254 eq 1985 0.0.0.0 255.255.255.254 eq 1985\n    20 deny udp any eq 1985 any eq 1985\n    30 deny icmp any any fragments\n    40 permit icmp 0.0.0.0 255.255.255.0 any\n    50 deny icmp any any\n    60 deny ip any any\n    70 deny ip any host 10.10.10.0\n    80 deny ip any host 10.10.10.255\n    90 permit ip 0.0.0.0 255.255.255.0 any\n    10000 deny ip any any log\ncisco-c6503e#"
+      expectations:
+      - :title: 'test extended 10'
+        :ensure: 'present'
+        :entry: '10'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'permit'
+        :protocol: 'udp'
+        :source_address: '0.0.0.0'
+        :source_address_wildcard_mask: '255.255.255.254'
+        :source_eq: ['1985']
+        :destination_address: '0.0.0.0'
+        :destination_address_wildcard_mask: '255.255.255.254'
+        :destination_eq: ['1985']
+      - :title: 'test extended 20'
+        :ensure: 'present'
+        :entry: '20'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'deny'
+        :protocol: 'udp'
+        :source_address_any: true
+        :source_eq: ['1985']
+        :destination_address_any: true
+        :destination_eq: ['1985']
+      - :title: 'test extended 30'
+        :ensure: 'present'
+        :entry: '30'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'deny'
+        :protocol: 'icmp'
+        :source_address_any: true
+        :destination_address_any: true
+        :fragments: true
+      - :title: 'test extended 40'
+        :ensure: 'present'
+        :entry: '40'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'permit'
+        :protocol: 'icmp'
+        :source_address: '0.0.0.0'
+        :source_address_wildcard_mask: '255.255.255.0'
+        :destination_address_any: true
+      - :title: 'test extended 50'
+        :ensure: 'present'
+        :entry: '50'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'deny'
+        :protocol: 'icmp'
+        :source_address_any: true
+        :destination_address_any: true
+      - :title: 'test extended 60'
+        :ensure: 'present'
+        :entry: '60'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'deny'
+        :protocol: 'ip'
+        :source_address_any: true
+        :destination_address_any: true
+      - :title: 'test extended 70'
+        :ensure: 'present'
+        :entry: '70'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'deny'
+        :protocol: 'ip'
+        :source_address_any: true
+        :destination_address_host: '10.10.10.0'
+      - :title: 'test extended 80'
+        :ensure: 'present'
+        :entry: '80'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'deny'
+        :protocol: 'ip'
+        :source_address_any: true
+        :destination_address_host: '10.10.10.255'
+      - :title: 'test extended 90'
+        :ensure: 'present'
+        :entry: '90'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'permit'
+        :protocol: 'ip'
+        :source_address: '0.0.0.0'
+        :source_address_wildcard_mask: '255.255.255.0'
+        :destination_address_any: true
+      - :title: 'test extended 10000'
+        :ensure: 'present'
+        :entry: '10000'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :permission: 'deny'
+        :protocol: 'ip'
+        :source_address_any: true
+        :destination_address_any: true
+        :log: true
+    "Everything Everything":
+      cli: "show ip access-lists\nExtended IP access list test42\n    11 permit tcp 1.2.3.4 4.4.4.4 eq 22 telnet 8080 whois host 5.4.3.2 range 22 8888 ack dscp test fin fragments log match-all +test1 -test2 match-any +test3 -test4 option testoption precedence testprecedence psh reflect testreflect timeout 4545 rst syn time-range 0800-1500 tos testtos urg\ncisco-c6503e#"
+      expectations:
+      - :title: 'test42 extended 11'
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: 'test42'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :entry: '11'
+        :source_address: '1.2.3.4'
+        :source_address_wildcard_mask: '4.4.4.4'
+        :source_eq: ['22', 'telnet', '8080', 'whois']
+        :destination_address_host: '5.4.3.2'
+        :destination_range: ['22', '8888']
+        :ack: true
+        :dscp: 'test'
+        :fin: true
+        :fragments: true
+        :log: true
+        :match_all: ['+test1', '-test2']
+        :match_any: ['+test3', '-test4']
+        :option: 'testoption'
+        :precedence: 'testprecedence'
+        :psh: true
+        :reflect: 'testreflect'
+        :reflect_timeout: 4545
+        :rst: true
+        :syn: true
+        :time_range: '0800-1500'
+        :tos: 'testtos'
+        :urg: true
+    "Protocol as integer":
+      cli: "show ip access-lists\nExtended IP access list test\n    10 permit udp any 0.0.0.2 255.255.255.0 log\n    20 permit 8 host 1.1.1.1 any precedence routine tos max-reliability option traceroute log-input fragments\ncisco-c6503e#"
+      expectations:
+      - :title: 'test extended 10'
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :protocol: 'udp'
+        :log: true
+        :entry: '10'
+        :source_address_any: true
+        :destination_address: '0.0.0.2'
+        :destination_address_wildcard_mask: '255.255.255.0'
+      - :title: 'test extended 20'
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :protocol: '8'
+        :log_input: true
+        :entry: '20'
+        :precedence: 'routine'
+        :tos: 'max-reliability'
+        :option: 'traceroute'
+        :fragments: true
+        :source_address_host: '1.1.1.1'
+        :destination_address_any: true
+    "Evaluate":
+      cli: "show ip access-lists\nExtended IP access list inboundfilters\n    10 permit eigrp any any\n    20 deny icmp any any\n    30 evaluate tcptraffic\nExtended IP access list outboundfilters\n    10 permit tcp any any reflect tcptraffic\nReflexive IP access list tcptraffic\ncisco-c6503e#"
+      expectations:
+      - :title: 'inboundfilters extended 10'
+        :ensure: 'present'
+        :entry: '10'
+        :permission: 'permit'
+        :access_list: 'inboundfilters'
+        :access_list_type: 'extended'
+        :protocol: 'eigrp'
+        :source_address_any: true
+        :destination_address_any: true
+      - :title: 'inboundfilters extended 20'
+        :ensure: 'present'
+        :entry: '20'
+        :permission: 'deny'
+        :access_list: 'inboundfilters'
+        :access_list_type: 'extended'
+        :protocol: 'icmp'
+        :source_address_any: true
+        :destination_address_any: true
+      - :title: 'inboundfilters extended 30'
+        :ensure: 'present'
+        :entry: '30'
+        :permission: 'evaluate'
+        :access_list: 'inboundfilters'
+        :access_list_type: 'extended'
+        :evaluation_name: 'tcptraffic'
+      - :title: 'outboundfilters extended 10'
+        :ensure: 'present'
+        :entry: '10'
+        :permission: 'permit'
+        :access_list: 'outboundfilters'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :source_address_any: true
+        :destination_address_any: true
+        :reflect: 'tcptraffic'
+    "UDP ports":
+      cli: "show ip access-lists\nExtended IP access list udpports\n    20 permit udp 2.3.4.5 0.0.0.255 eq snmptrap 4.5.6.7 0.0.0.255\n    40 permit udp host 1.2.3.4 eq ntp 4.5.6.7 0.0.0.255\n    80 permit udp host 5.6.7.8 gt 1023 4.5.6.7 0.0.0.255 eq snmp\n    90 permit udp host 9.8.7.6 gt 1023 4.5.6.7 0.0.0.255 eq snmp\ncisco-c6503e#"
+      expectations:
+      - :title: 'udpports extended 20'
+        :ensure: 'present'
+        :entry: '20'
+        :permission: 'permit'
+        :access_list: 'udpports'
+        :access_list_type: 'extended'
+        :protocol: 'udp'
+        :source_address: '2.3.4.5'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :source_eq: ['snmptrap']
+        :destination_address: '4.5.6.7'
+        :destination_address_wildcard_mask: '0.0.0.255'
+      - :title: 'udpports extended 40'
+        :ensure: 'present'
+        :entry: '40'
+        :permission: 'permit'
+        :access_list: 'udpports'
+        :access_list_type: 'extended'
+        :protocol: 'udp'
+        :source_address_host: '1.2.3.4'
+        :source_eq: ['ntp']
+        :destination_address: '4.5.6.7'
+        :destination_address_wildcard_mask: '0.0.0.255'
+      - :title: 'udpports extended 80'
+        :access_list: 'udpports'
+        :access_list_type: 'extended'
+        :destination_address: '4.5.6.7'
+        :destination_address_wildcard_mask: '0.0.0.255'
+        :destination_eq: ['snmp']
+        :ensure: 'present'
+        :entry: '80'
+        :permission: 'permit'
+        :protocol: 'udp'
+        :source_address_host: '5.6.7.8'
+        :source_gt: '1023'
+      - :title: 'udpports extended 90'
+        :access_list: 'udpports'
+        :access_list_type: 'extended'
+        :destination_address: '4.5.6.7'
+        :destination_address_wildcard_mask: '0.0.0.255'
+        :destination_eq: ['snmp']
+        :ensure: 'present'
+        :entry: '90'
+        :permission: 'permit'
+        :protocol: 'udp'
+        :source_address_host: '9.8.7.6'
+        :source_gt: '1023'
+    "ICMP and IGMP tests":
+      cli: "show ip access-lists\nExtended IP access list test1\n    100 permit icmp 1.2.3.0 0.0.0.255 any time-exceeded log\n    110 permit icmp 2.3.4.0 0.0.0.255 any echo-reply\n    120 permit icmp 3.4.5.0 0.0.0.255 any 42 43\n    130 permit igmp any any 9\n    140 permit igmp any any 4\ncisco-c6503e#"
+      expectations:
+      - :title: 'test1 extended 100'
+        :entry: '100'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'icmp'
+        :source_address: '1.2.3.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :icmp_message_type: 'time-exceeded'
+        :log: true
+      - :title: 'test1 extended 110'
+        :entry: '110'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'icmp'
+        :source_address: '2.3.4.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :icmp_message_type: 'echo-reply'
+      - :title: 'test1 extended 120'
+        :entry: '120'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'icmp'
+        :source_address: '3.4.5.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :icmp_message_type: 42
+        :icmp_message_code: 43
+      - :title: 'test1 extended 130'
+        :entry: '130'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'igmp'
+        :source_address_any: true
+        :destination_address_any: true
+        :igmp_message_type: 9
+      - :title: 'test1 extended 140'
+        :entry: '140'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'igmp'
+        :source_address_any: true
+        :destination_address_any: true
+        :igmp_message_type: 4
+    "Special chars":
+      cli: "show ip access-lists\nExtended IP access list ~!@#$%^&*()_+-={}[]\\:;'<>,./.\n      10 permit tcp 192.168.10.0 0.0.0.255 any eq 22 log\ncisco-c6503e#"
+      expectations:
+      - :title: "~!@#$%^&*()_+-={}[]\\:;'<>,./. extended 10"
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: "~!@#$%^&*()_+-={}[]\\:;'<>,./."
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :log: true
+        :entry: '10'
+        :source_address: '192.168.10.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :destination_eq: ['22']
+  update_tests:
+    "DT 10":
+      commands:
+      - "10 permit tcp 192.168.10.0 0.0.0.255 any eq 22 log"
+      instance:
+        :title: 'test1 extended 10'
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :log: true
+        :entry: '10'
+        :source_address: '192.168.10.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :destination_eq: ['22']
+    "DT 20":
+      commands:
+      - "20 permit udp 192.168.10.0 0.0.0.255 any"
+      instance:
+        :title: 'test1 extended 20'
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'udp'
+        :entry: '20'
+        :source_address: '192.168.10.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+    "DT 30":
+      commands:
+      - "30 deny ip any any log"
+      instance:
+        :title: 'test1 extended 30'
+        :ensure: 'present'
+        :permission: 'deny'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'ip'
+        :entry: '30'
+        :source_address_any: true
+        :destination_address_any: true
+        :log: true
+    "Everything Everything":
+      commands:
+      - "11 permit tcp 1.2.3.4 4.4.4.4 eq 22 telnet 8080 whois gt 54 lt 9000 neq 8081 portgroup port1 range 21 8999 host 5.4.3.2 eq 34 www gt 10 lt 1000 neq 999 portgroup port2 range 22 8888 ack dscp test fin fragments log match-all +test1 -test2 match-any +test3 -test4 option testoption precedence testprecedence psh reflect testreflect timeout 4545 rst syn time-range 0800-1500 tos testtos urg"
+      instance:
+        :title: 'test42 extended 11'
+        :ensure: 'present'
+        :permission: 'permit'
+        :access_list: 'test42'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :entry: '11'
+        :source_address: '1.2.3.4'
+        :source_address_wildcard_mask: '4.4.4.4'
+        :source_eq: ['22', 'telnet', '8080', 'whois']
+        :source_gt: '54'
+        :source_lt: '9000'
+        :source_neq: '8081'
+        :source_portgroup: 'port1'
+        :source_range: ['21', '8999']
+        :destination_address_host: '5.4.3.2'
+        :destination_eq: ['34', 'www']
+        :destination_gt: '10'
+        :destination_lt: '1000'
+        :destination_neq: '999'
+        :destination_portgroup: 'port2'
+        :destination_range: ['22', '8888']
+        :ack: true
+        :dscp: 'test'
+        :fin: true
+        :fragments: true
+        :log: true
+        :match_all: ['+test1', '-test2']
+        :match_any: ['+test3', '-test4']
+        :option: 'testoption'
+        :precedence: 'testprecedence'
+        :psh: true
+        :reflect: 'testreflect'
+        :reflect_timeout: 4545
+        :rst: true
+        :syn: true
+        :time_range: '0800-1500'
+        :tos: 'testtos'
+        :urg: true
+    "Dynamic list test 1":
+      commands:
+      - "4 Dynamic eek permit ip any 192.168.0.0 0.0.255.255 log"
+      instance:
+        :title: 'test extended 4'
+        :ensure: 'present'
+        :dynamic: 'eek'
+        :permission: 'permit'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :protocol: 'ip'
+        :log: true
+        :entry: '4'
+        :source_address_any: true
+        :destination_address: '192.168.0.0'
+        :destination_address_wildcard_mask: '0.0.255.255'
+    "Dynamic list test 2":
+      commands:
+      - "10 Dynamic testlist permit ip any any log"
+      instance:
+        :title: '120 extended 10'
+        :ensure: 'present'
+        :entry: '10'
+        :dynamic: 'testlist'
+        :permission: 'permit'
+        :access_list: '120'
+        :access_list_type: 'extended'
+        :protocol: 'ip'
+        :log: true
+        :source_address_any: true
+        :destination_address_any: true
+    "Evaluate":
+      commands:
+      - "30 evaluate tcptraffic"
+      instance:
+        :title: 'inboundfilters extended 30'
+        :ensure: 'present'
+        :entry: '30'
+        :permission: 'evaluate'
+        :access_list: 'inboundfilters'
+        :access_list_type: 'extended'
+        :evaluation_name: 'tcptraffic'
+    "UDP ports 20":
+      commands:
+      - "20 permit udp 2.3.4.5 0.0.0.255 eq snmptrap 4.5.6.7 0.0.0.255"
+      instance:
+        :title: 'test extended 20'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :entry: '20'
+        :permission: 'permit'
+        :access_list: 'test'
+        :protocol: 'udp'
+        :source_address: '2.3.4.5'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :source_eq: ['snmptrap']
+        :destination_address: '4.5.6.7'
+        :destination_address_wildcard_mask: '0.0.0.255'
+    "UDP ports 40":
+      commands:
+      - "40 permit udp host 1.2.3.4 eq ntp 4.5.6.7 0.0.0.255"
+      instance:
+        :title: 'test extended 40'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :entry: '40'
+        :permission: 'permit'
+        :access_list: 'test'
+        :protocol: 'udp'
+        :source_address_host: '1.2.3.4'
+        :source_eq: ['ntp']
+        :destination_address: '4.5.6.7'
+        :destination_address_wildcard_mask: '0.0.0.255'
+    "UDP ports 80":
+      commands:
+      - "80 permit udp host 5.6.7.8 gt 1023 4.5.6.7 0.0.0.255 eq snmp"
+      instance:
+        :title: 'test extended 80'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :destination_address: '4.5.6.7'
+        :destination_address_wildcard_mask: '0.0.0.255'
+        :destination_eq: ['snmp']
+        :ensure: 'present'
+        :entry: '80'
+        :permission: 'permit'
+        :protocol: 'udp'
+        :source_address_host: '5.6.7.8'
+        :source_gt: '1023'
+    "UDP ports 90":
+      commands:
+      - "90 permit udp host 9.8.7.6 gt 1023 4.5.6.7 0.0.0.255 eq snmp"
+      instance:
+        :title: 'test extended 90'
+        :access_list: 'test'
+        :access_list_type: 'extended'
+        :destination_address: '4.5.6.7'
+        :destination_address_wildcard_mask: '0.0.0.255'
+        :destination_eq: ['snmp']
+        :ensure: 'present'
+        :entry: '90'
+        :permission: 'permit'
+        :protocol: 'udp'
+        :source_address_host: '9.8.7.6'
+        :source_gt: '1023'
+    "ICMP 100":
+      commands:
+      - "100 permit icmp 1.2.3.0 0.0.0.255 any time-exceeded log"
+      instance:
+        :title: 'test1 extended 100'
+        :entry: '100'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'icmp'
+        :source_address: '1.2.3.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :icmp_message_type: 'time-exceeded'
+        :log: true
+    "ICMP 110":
+      commands:
+      - "110 permit icmp 2.3.4.0 0.0.0.255 any echo-reply"
+      instance:
+        :title: 'test1 extended 110'
+        :entry: '110'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'icmp'
+        :source_address: '2.3.4.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :icmp_message_type: 'echo-reply'
+        :icmp_message_code: 42
+    "ICMP 120":
+      commands:
+      - "120 permit icmp 3.4.5.0 0.0.0.255 any 42 43"
+      instance:
+        :title: 'test1 extended 120'
+        :entry: '120'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'icmp'
+        :source_address: '3.4.5.0'
+        :source_address_wildcard_mask: '0.0.0.255'
+        :destination_address_any: true
+        :icmp_message_type: 42
+        :icmp_message_code: 43
+    "IGMP 130":
+      commands:
+      - "130 permit igmp any any 9"
+      instance:
+        :title: 'test1 extended 130'
+        :entry: '130'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'igmp'
+        :source_address_any: true
+        :destination_address_any: true
+        :igmp_message_type: 9
+    "IGMP 140":
+      commands:
+      - "140 permit igmp any any 4"
+      instance:
+        :title: 'test1 extended 140'
+        :entry: '140'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :ensure: 'present'
+        :protocol: 'igmp'
+        :source_address_any: true
+        :destination_address_any: true
+        :igmp_message_type: 4
+    "Standard":
+      commands:
+      - "10 deny 1.2.3.4"
+      instance:
+        :title: 'test2 standard 10'
+        :ensure: 'present'
+        :entry: '10'
+        :permission: 'deny'
+        :access_list: 'test2'
+        :access_list_type: 'standard'
+        :source_address: '1.2.3.4'
+    "Remove":
+      commands:
+      - "no 10 permit tcp any any log"
+      instance:
+        :title: 'test1 extended 10'
+        :ensure: 'absent'
+        :entry: '10'
+        :permission: 'permit'
+        :access_list: 'test1'
+        :access_list_type: 'extended'
+        :protocol: 'tcp'
+        :source_address_any: true
+        :destination_address_any: true
+        :log: true

--- a/spec/unit/puppet/type/ios_acl_spec.rb
+++ b/spec/unit/puppet/type/ios_acl_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+describe 'the ios_acl type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:ios_acl)).not_to be_nil
+  end
+end


### PR DESCRIPTION
Prior to this work `ios_access_list` allowed for a named access list to be created without function, and  it was not possible to create a numbered access list.

This work merges `ios_access_list` and `ios_acl_entry` into one type: ios_acl_entry.

Resources will use the title_pattern  of `<access_list> <access_list_type> <entry>` e.g. `RepelInvaders extended 10` will create the `RepelInvaders` access list as an `extended` named list with the priority entry `10`.  While `10 standard 10` will create the numbered access list 10 as standard with a priority entry 10.