### PR TITLE
(PE-29241) Use all supported algorithms for ssh connections

### DIFF
--- a/lib/puppet/transport/cisco_ios.rb
+++ b/lib/puppet/transport/cisco_ios.rb
@@ -56,7 +56,8 @@ module Puppet::Transport
                                  port: config[:port] || 22,
                                  timeout: config[:timeout] || 30,
                                  verify_host_key => false,
-                                 user_known_hosts_file: known_hosts_file)
+                                 user_known_hosts_file: known_hosts_file,
+                                 append_all_supported_algorithms: true)
                 else
                   Net::SSH.start(config[:host],
                                  config[:user],
@@ -64,7 +65,8 @@ module Puppet::Transport
                                  port: config[:port] || 22,
                                  timeout: config[:timeout] || 30,
                                  verify_host_key => :very,
-                                 user_known_hosts_file: known_hosts_file)
+                                 user_known_hosts_file: known_hosts_file,
+                                 append_all_supported_algorithms: true)
                 end
 
       @options = { 'Prompt' =>  %r{#{commands['default']['connect_prompt']}},


### PR DESCRIPTION
Some older, less secure algorithms have been deprecated with net-ssh 6.x (which is what is available in the context the ace server in PE executes remote tasks). This commit adds an option to net-ssh to include the less secure algorithms which are on the path to deprecation until they are formally deprecated/removed.