### PR TITLE
(maint) - Update author from Puppet to puppetlabs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "puppetlabs-cisco_ios",
   "version": "1.3.0",
-  "author": "Puppet",
+  "author": "puppetlabs",
   "summary": "Management of Cisco Catalyst (IOS, IOS-XE)",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/cisco_ios",


### PR DESCRIPTION
This allows the module to be uploaded to the Forge automatically when kicking off the generic release job.