### PR TITLE
(IAC-1603) Removing usage of resource_api module and puppet5 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,4 +5,3 @@ fixtures:
   forge_modules:
     netdev_stdlib: "puppetlabs/netdev_stdlib"
     puppetserver_gem: "puppetlabs/puppetserver_gem"
-    resource_api: "puppetlabs/resource_api"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ jobs:
       env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static
     -
-      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.5
-      stage: spec
-    -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.7
       stage: spec

--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ The `--modulepath` param can be retrieved by typing `puppet config print modulep
 ### Type
 
 Add new types to the type directory.
-We use the [Resource API format](https://github.com/puppetlabs/puppet-resource_api/blob/main/README.md)
 Use the bundled ios_config example for guidance. Here is a simple example:
 
 ```Ruby

--- a/manifests/install/agent.pp
+++ b/manifests/install/agent.pp
@@ -4,8 +4,6 @@
 #   include cisco_ios::install::agent
 class cisco_ios::install::agent {
 
-  include resource_api::install
-
   package { 'net-ssh-telnet':
     ensure   => present,
     provider => 'puppet_gem',

--- a/manifests/install/server.pp
+++ b/manifests/install/server.pp
@@ -4,5 +4,4 @@
 # @example Declaring the class
 #   include cisco_ios::install::server
 class cisco_ios::install::server {
-  include resource_api::install::server
 }

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -6,8 +6,6 @@
 # @note Deprecated, use cisco_ios::install::agent
 class cisco_ios::proxy {
 
-  include resource_api::agent
-
   package { 'net-ssh-telnet':
     ensure   => present,
     provider => 'puppet_gem',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -6,5 +6,4 @@
 #
 # @note Deprecated, use cisco_ios::install::server
 class cisco_ios::server {
-  include resource_api::server
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,10 +8,6 @@
   "issues_url": "https://tickets.puppetlabs.com/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&customfield_14200=19807&priority=6",
   "dependencies": [
     {
-      "name": "puppetlabs/resource_api",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
-    },
-    {
       "name": "puppetlabs/netdev_stdlib",
       "version_requirement": ">= 0.19.0 < 1.0.0"
     }

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
As of puppet6, the resource_api gem is automatically included in Puppet therefore the module has been deprecated. Removing all references to the resource_api module in the codebase.